### PR TITLE
Add correct fan out, decouple Redis reads, add dedup for messages

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,8 @@ redis:
 server:
   host: "0.0.0.0"
   port: 8080
+  broadcast_buffer_size: 100
+  polling_interval_seconds: 5
 leaderboard:
   update_interval_secs: 5
   top_players_limit: 10

--- a/src/backend/sse.go
+++ b/src/backend/sse.go
@@ -35,7 +35,7 @@ func CreateLeaderboardBroadcaster() *LeaderboardBroadcaster {
 
 	lb := &LeaderboardBroadcaster{
 		// make the channel buffered - clients may be slow, messages can pile up
-		broadcastChan: make(chan LeaderboardUpdate, 100),
+		broadcastChan: make(chan LeaderboardUpdate, config.AppConfig.Server.BroadcastBufferSize),
 		ctx:           ctx,
 		cancel:        cancel,
 	}
@@ -65,7 +65,8 @@ func SetBroadcaster(b *LeaderboardBroadcaster) {
 func (lb *LeaderboardBroadcaster) detectLeaderboardChanges() {
 	defer lb.wg.Done()
 
-	ticker := time.NewTicker(5 * time.Second)
+	// TODO: check this time conversion
+	ticker := time.NewTicker(time.Duration(config.AppConfig.Server.PollingIntervalSeconds) * time.Second)
 	defer ticker.Stop()
 
 	var lastHash [32]byte
@@ -76,8 +77,8 @@ func (lb *LeaderboardBroadcaster) detectLeaderboardChanges() {
 			results, err := redisclient.GetTopNPlayers(lb.ctx, "leaderboard", int64(config.AppConfig.Leaderboard.TopPlayersLimit))
 			if err != nil {
 				metrics.RedisOperationErrors.WithLabelValues("get_top_players").Inc()
+				config.Error("Failed to fetch leaderboard from Redis.", map[string]any{"Error": err, "source": "/stream-leaderboard"})
 				continue
-				// TODO: add logging
 			}
 
 			resultString := fmt.Sprintf("%+v", results)
@@ -88,12 +89,13 @@ func (lb *LeaderboardBroadcaster) detectLeaderboardChanges() {
 
 				jsonStart := time.Now()
 				jsonData, err := json.Marshal(results)
-				metrics.JSONMarshalDuration.Observe(time.Since(jsonStart).Seconds())
-
 				if err != nil {
+					config.Error("JSON marshaling error",
+						map[string]any{"Error": err, "source": "/stream-leaderboard", "results": results})
 					metrics.JSONErrors.WithLabelValues("marshal").Inc()
-					return
+					continue
 				}
+				metrics.JSONMarshalDuration.Observe(time.Since(jsonStart).Seconds())
 
 				update := LeaderboardUpdate{
 					Data: jsonData,
@@ -122,6 +124,7 @@ func StreamLeaderboard(c *gin.Context) {
 	c.Writer.Flush()
 
 	metrics.ActiveSSEConnections.Inc()
+	config.Info("New SSE conn", map[string]any{"Num active clients": metrics.ActiveSSEConnections})
 	defer metrics.ActiveSSEConnections.Dec()
 
 	broadcastChan := broadcaster.GetBroadcastChannel()
@@ -139,6 +142,7 @@ func StreamLeaderboard(c *gin.Context) {
 
 		case <-c.Request.Context().Done():
 			metrics.DroppedSSEConnections.Inc()
+			config.Info("Closed SSE conn", map[string]any{"open": metrics.ActiveSSEConnections})
 			return
 		}
 	}

--- a/src/backend/sse.go
+++ b/src/backend/sse.go
@@ -1,15 +1,116 @@
 package backend
 
 import (
+	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"leaderboard/src/config"
 	"leaderboard/src/metrics"
 	"leaderboard/src/redisclient"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 )
+
+type LeaderboardUpdate struct {
+	Data []byte
+	Hash [32]byte
+}
+
+type LeaderboardBroadcaster struct {
+	// channel for all SSE conns to listen to get lb updates
+	broadcastChan chan LeaderboardUpdate
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// enable goroutines to run before moving on, to be used for locks
+	wg sync.WaitGroup
+}
+
+func CreateLeaderboardBroadcaster() *LeaderboardBroadcaster {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	lb := &LeaderboardBroadcaster{
+		// make the channel buffered - clients may be slow, messages can pile up
+		broadcastChan: make(chan LeaderboardUpdate, 100),
+		ctx:           ctx,
+		cancel:        cancel,
+	}
+
+	lb.wg.Add(1)
+	go lb.detectLeaderboardChanges()
+	return lb
+}
+
+func (lb *LeaderboardBroadcaster) StopBroadcast() {
+	lb.cancel()
+	lb.wg.Wait()
+	close(lb.broadcastChan)
+}
+
+func (lb *LeaderboardBroadcaster) GetBroadcastChannel() <-chan LeaderboardUpdate {
+	return lb.broadcastChan
+}
+
+// package level var
+var broadcaster *LeaderboardBroadcaster
+
+func SetBroadcaster(b *LeaderboardBroadcaster) {
+	broadcaster = b
+}
+
+func (lb *LeaderboardBroadcaster) detectLeaderboardChanges() {
+	defer lb.wg.Done()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	var lastHash [32]byte
+
+	for {
+		select {
+		case <-ticker.C:
+			results, err := redisclient.GetTopNPlayers(lb.ctx, "leaderboard", int64(config.AppConfig.Leaderboard.TopPlayersLimit))
+			if err != nil {
+				metrics.RedisOperationErrors.WithLabelValues("get_top_players").Inc()
+				continue
+				// TODO: add logging
+			}
+
+			resultString := fmt.Sprintf("%+v", results)
+			currentHash := sha256.Sum256([]byte(resultString))
+
+			if currentHash != lastHash {
+				lastHash = currentHash
+
+				jsonStart := time.Now()
+				jsonData, err := json.Marshal(results)
+				metrics.JSONMarshalDuration.Observe(time.Since(jsonStart).Seconds())
+
+				if err != nil {
+					metrics.JSONErrors.WithLabelValues("marshal").Inc()
+					return
+				}
+
+				update := LeaderboardUpdate{
+					Data: jsonData,
+					Hash: currentHash,
+				}
+
+				// non blocking send
+				select {
+				case lb.broadcastChan <- update:
+				default:
+				}
+			}
+		case <-lb.ctx.Done():
+			return
+		}
+	}
+}
 
 func StreamLeaderboard(c *gin.Context) {
 	metrics.ConcurrentClients.Inc()
@@ -23,44 +124,22 @@ func StreamLeaderboard(c *gin.Context) {
 	metrics.ActiveSSEConnections.Inc()
 	defer metrics.ActiveSSEConnections.Dec()
 
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-
-	var lastData []byte
+	broadcastChan := broadcaster.GetBroadcastChannel()
 
 	for {
 		select {
-		case <-ticker.C:
-			results, err := redisclient.GetTopNPlayers(c, "leaderboard", int64(config.AppConfig.Leaderboard.TopPlayersLimit))
-			if err != nil {
-				metrics.RedisOperationErrors.WithLabelValues("get_top_players").Inc()
-			}
-
-			jsonStart :=time.Now()
-
-			data, err := json.Marshal(results)
-			metrics.JSONMarshalDuration.Observe(time.Since(jsonStart).Seconds())
-    
-			if err != nil {
-				metrics.JSONErrors.WithLabelValues("marshal").Inc()
+		case update, ok := <-broadcastChan:
+			if !ok {
+				// channel closed
 				return
 			}
-
-
-			if !jsonEqual(data, lastData) {
-				fmt.Fprintf(c.Writer, "data: %s\n\n", data)
-				c.Writer.Flush()
-				metrics.SSEMessagesSent.Inc()
-				lastData = data
-			}
+			fmt.Fprintf(c.Writer, "data: %s\n\n", update.Data)
+			c.Writer.Flush()
+			metrics.SSEMessagesSent.Inc()
 
 		case <-c.Request.Context().Done():
 			metrics.DroppedSSEConnections.Inc()
 			return
 		}
 	}
-}
-
-func jsonEqual(a, b []byte) bool {
-	return string(a) == string(b)
 }

--- a/src/backend/sse.go
+++ b/src/backend/sse.go
@@ -19,15 +19,20 @@ type LeaderboardUpdate struct {
 	Hash [32]byte
 }
 
+type Client struct {
+	ID      int64
+	channel chan LeaderboardUpdate
+	ctx     context.Context
+	cancel  context.CancelFunc
+}
+
 type LeaderboardBroadcaster struct {
-	// channel for all SSE conns to listen to get lb updates
-	broadcastChan chan LeaderboardUpdate
-
-	ctx    context.Context
-	cancel context.CancelFunc
-
-	// enable goroutines to run before moving on, to be used for locks
-	wg sync.WaitGroup
+	clients       map[int64]*Client
+	clientsMutex  sync.RWMutex
+	ctx           context.Context
+	cancel        context.CancelFunc
+	wg            sync.WaitGroup
+	clientCounter int64
 }
 
 func CreateLeaderboardBroadcaster() *LeaderboardBroadcaster {
@@ -35,9 +40,9 @@ func CreateLeaderboardBroadcaster() *LeaderboardBroadcaster {
 
 	lb := &LeaderboardBroadcaster{
 		// make the channel buffered - clients may be slow, messages can pile up
-		broadcastChan: make(chan LeaderboardUpdate, config.AppConfig.Server.BroadcastBufferSize),
-		ctx:           ctx,
-		cancel:        cancel,
+		clients: make(map[int64]*Client),
+		ctx:     ctx,
+		cancel:  cancel,
 	}
 
 	lb.wg.Add(1)
@@ -45,14 +50,80 @@ func CreateLeaderboardBroadcaster() *LeaderboardBroadcaster {
 	return lb
 }
 
+// should have an endpoint, with proper auth - admin only
 func (lb *LeaderboardBroadcaster) StopBroadcast() {
 	lb.cancel()
 	lb.wg.Wait()
-	close(lb.broadcastChan)
+
+	lb.clientsMutex.Lock()
+	defer lb.clientsMutex.Unlock()
+	// remove all clients
+	for _, client := range lb.clients {
+		client.cancel()
+		close(client.channel)
+	}
 }
 
-func (lb *LeaderboardBroadcaster) GetBroadcastChannel() <-chan LeaderboardUpdate {
-	return lb.broadcastChan
+// Create new channel for client, add to map
+func (lb *LeaderboardBroadcaster) AddClient() (*Client, <-chan LeaderboardUpdate) {
+	lb.clientsMutex.Lock()
+	lb.clientCounter++
+	ctx, cancel := context.WithCancel(lb.ctx)
+
+	client := &Client{
+		ID:      lb.clientCounter,
+		ctx:     ctx,
+		cancel:  cancel,
+		channel: make(chan LeaderboardUpdate, config.AppConfig.Server.BroadcastBufferSize),
+	}
+	lb.clients[lb.clientCounter] = client
+	lb.clientsMutex.Unlock()
+
+	return client, client.channel
+}
+
+// remove specific client channel - closed connection
+func (lb *LeaderboardBroadcaster) RemoveClient(client *Client) {
+	lb.clientsMutex.Lock()
+	defer lb.clientsMutex.Unlock()
+
+	if _, exists := lb.clients[client.ID]; exists {
+		delete(lb.clients, client.ID)
+		client.cancel()
+		close(client.channel)
+	}
+}
+
+// broadcastToAllClients sends an update to all connected clients
+func (lb *LeaderboardBroadcaster) broadcastToAllClients(update LeaderboardUpdate) {
+	lb.clientsMutex.RLock()
+
+	var clientsToRemove []*Client
+
+	// what to do in case Client channel is full, skip this client (to be changed later - add channel clearing mechanism + alerting)
+	for _, client := range lb.clients {
+		select {
+		case client.channel <- update:
+			// sent
+		case <-client.ctx.Done():
+			// clean
+			clientsToRemove = append(clientsToRemove, client)
+		default:
+		}
+	}
+	lb.clientsMutex.RUnlock()
+
+	if len(clientsToRemove) > 0 {
+		lb.clientsMutex.Lock()
+		for _, client := range clientsToRemove {
+			if _, exists := lb.clients[client.ID]; exists {
+				delete(lb.clients, client.ID)
+				client.cancel()
+				close(client.channel)
+			}
+		}
+		lb.clientsMutex.Unlock()
+	}
 }
 
 // package level var
@@ -62,10 +133,9 @@ func SetBroadcaster(b *LeaderboardBroadcaster) {
 	broadcaster = b
 }
 
+// poll redis, dedup leaderboard values, push to broadcast to all clients
 func (lb *LeaderboardBroadcaster) detectLeaderboardChanges() {
 	defer lb.wg.Done()
-
-	// TODO: check this time conversion
 	ticker := time.NewTicker(time.Duration(config.AppConfig.Server.PollingIntervalSeconds) * time.Second)
 	defer ticker.Stop()
 
@@ -102,11 +172,7 @@ func (lb *LeaderboardBroadcaster) detectLeaderboardChanges() {
 					Hash: currentHash,
 				}
 
-				// non blocking send
-				select {
-				case lb.broadcastChan <- update:
-				default:
-				}
+				lb.broadcastToAllClients(update)
 			}
 		case <-lb.ctx.Done():
 			return
@@ -127,11 +193,12 @@ func StreamLeaderboard(c *gin.Context) {
 	config.Info("New SSE conn", map[string]any{"Num active clients": metrics.ActiveSSEConnections})
 	defer metrics.ActiveSSEConnections.Dec()
 
-	broadcastChan := broadcaster.GetBroadcastChannel()
+	client, channel := broadcaster.AddClient()
+	defer broadcaster.RemoveClient(client)
 
 	for {
 		select {
-		case update, ok := <-broadcastChan:
+		case update, ok := <-channel:
 			if !ok {
 				// channel closed
 				return
@@ -139,7 +206,6 @@ func StreamLeaderboard(c *gin.Context) {
 			fmt.Fprintf(c.Writer, "data: %s\n\n", update.Data)
 			c.Writer.Flush()
 			metrics.SSEMessagesSent.Inc()
-
 		case <-c.Request.Context().Done():
 			metrics.DroppedSSEConnections.Inc()
 			config.Info("Closed SSE conn", map[string]any{"open": metrics.ActiveSSEConnections})

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -18,8 +18,10 @@ type Config struct {
 	} `yaml:"redis"`
 
 	Server struct {
-		Port int    `yaml:"port"`
-		Host string `yaml:"host"`
+		Port                   int    `yaml:"port"`
+		Host                   string `yaml:"host"`
+		BroadcastBufferSize    int    `yaml:"broadcast_buffer_size"`
+		PollingIntervalSeconds int    `yaml:"polling_interval_seconds"`
 	} `yaml:"server"`
 
 	Leaderboard struct {

--- a/src/main.go
+++ b/src/main.go
@@ -25,6 +25,11 @@ func main() {
 	redisclient.InitRedis()
 	metrics.InitMetrics()
 
+	broadcaster := backend.CreateLeaderboardBroadcaster()
+	defer broadcaster.StopBroadcast()
+
+	backend.SetBroadcaster(broadcaster)
+
 	r := gin.Default()
 
 	r.Use(metrics.MetricsMiddleware())

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -73,8 +73,8 @@ var (
 		},
 	)
 
-	DroppedSSEConnections = prometheus.NewCounter(
-		prometheus.CounterOpts{
+	DroppedSSEConnections = prometheus.NewGauge(
+		prometheus.GaugeOpts{
 			Name: "dropped_sse_connections_total",
 			Help: "Total number of dropped SSE connections",
 		},


### PR DESCRIPTION
### This change brings a lot of major changes to the project:

1. Decoupling Redis reads from the main SSE loop (separate goroutine polls Redis every few seconds now)
2. Use hashing for deduplication
3. Reduce JSON marshaling frequency (only if change happens)
4. Buffered channels to do asynchronous push (to some extent)
5. Fixed fan out (earlier had only one channel for all clients, would not work - new client struct used with mapping in main Leaderboard)
6. Mutexes to prevent deadlocks and races


### Why was this necessary?
Initial implementation had inefficient resource utilization, duplicated resource creation, incorrect logic for fan out (and other components).

Fixing this was the only way to ensure this scales and performs functions as intended.


### What next?
- The code currently uses global variables (for leaderboard broadcaster). It would be better to change this through dependency injection, or some other way to enable easier testing and other functions.
- Current setup is stateful, which means it's not horizontally scalable. Could look into building a stateless version (storing state in Redis).
- Connection pooling for Redis does not make sense for the SSE part, but there are other access patterns. Need to implement and see what perf changes it brings (expected improvements across other access patterns).
- Reduce data sent over the network. Currently sending whole leaderboard, reduce to top 10 (or study access patterns in this kind of software), implement some kind of pagination. Not looking at Protobuf or similar right now, keep it simple to JSON.
- Figure out memory usage patterns (periodic dips - probably GC, but baseline rises soon).
- Figure out how to handle channel buffer overflows (High Priority).
- Player ID to username conversion before constructing message to send.
- Fix docs (keep in separate directory overall). Add the reasoning for each component, overall architecture explanation.