### PR TITLE
Fix/backpressure: add channel draining and monitoring

### DIFF
--- a/src/backend/sse.go
+++ b/src/backend/sse.go
@@ -108,12 +108,13 @@ func (lb *LeaderboardBroadcaster) broadcastToAllClients(update LeaderboardUpdate
 		default:
 			metrics.FilledSSEChannels.Inc()
 			// drain channel before pushing new update
+		drainLoop:
 			for {
 				select {
 				case <-client.channel:
 				default:
 					client.channel <- update
-					return
+					break drainLoop
 				}
 			}
 		}
@@ -163,6 +164,7 @@ func (lb *LeaderboardBroadcaster) detectLeaderboardChanges() {
 			if err != nil {
 				config.Error("JSON marshaling error", map[string]any{"Error": err, "source": "/stream-leaderboard"})
 				metrics.JSONErrors.WithLabelValues("marshal").Inc()
+				continue
 			}
 			metrics.JSONMarshalDuration.Observe(float64(time.Since(jsonStart).Seconds()))
 
@@ -203,7 +205,7 @@ func StreamLeaderboard(c *gin.Context) {
 		case update, ok := <-channel:
 			if !ok {
 				// channel closed
-				config.Error("Channel found closed on update", map[string]any{})
+				config.Info("Channel found closed on update", map[string]any{})
 				return
 			}
 			fmt.Fprintf(c.Writer, "data: %s\n\n", update.Data)
@@ -211,7 +213,7 @@ func StreamLeaderboard(c *gin.Context) {
 			metrics.SSEMessagesSent.Inc()
 		case <-c.Request.Context().Done():
 			metrics.DroppedSSEConnections.Inc()
-			config.Info("Closed SSE conn", map[string]any{})
+			config.Info("Closed SSE conn", map[string]any{"client ID": client.ID})
 			return
 		}
 	}

--- a/src/backend/sse.go
+++ b/src/backend/sse.go
@@ -39,7 +39,6 @@ func CreateLeaderboardBroadcaster() *LeaderboardBroadcaster {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	lb := &LeaderboardBroadcaster{
-		// make the channel buffered - clients may be slow, messages can pile up
 		clients: make(map[int64]*Client),
 		ctx:     ctx,
 		cancel:  cancel,
@@ -104,12 +103,19 @@ func (lb *LeaderboardBroadcaster) broadcastToAllClients(update LeaderboardUpdate
 	for _, client := range lb.clients {
 		select {
 		case client.channel <- update:
-			// sent
 		case <-client.ctx.Done():
-			// clean
 			clientsToRemove = append(clientsToRemove, client)
 		default:
 			metrics.FilledSSEChannels.Inc()
+			// drain channel before pushing new update
+			for {
+				select {
+				case <-client.channel:
+				default:
+					client.channel <- update
+					return
+				}
+			}
 		}
 	}
 	lb.clientsMutex.RUnlock()
@@ -152,27 +158,22 @@ func (lb *LeaderboardBroadcaster) detectLeaderboardChanges() {
 				continue
 			}
 
-			resultString := fmt.Sprintf("%+v", results)
-			currentHash := sha256.Sum256([]byte(resultString))
+			jsonStart := time.Now()
+			jsonData, err := json.Marshal(results)
+			if err != nil {
+				config.Error("JSON marshaling error", map[string]any{"Error": err, "source": "/stream-leaderboard"})
+				metrics.JSONErrors.WithLabelValues("marshal").Inc()
+			}
+			metrics.JSONMarshalDuration.Observe(float64(time.Since(jsonStart).Seconds()))
+
+			currentHash := sha256.Sum256(jsonData)
 
 			if currentHash != lastHash {
 				lastHash = currentHash
-
-				jsonStart := time.Now()
-				jsonData, err := json.Marshal(results)
-				if err != nil {
-					config.Error("JSON marshaling error",
-						map[string]any{"Error": err, "source": "/stream-leaderboard", "results": results})
-					metrics.JSONErrors.WithLabelValues("marshal").Inc()
-					continue
-				}
-				metrics.JSONMarshalDuration.Observe(time.Since(jsonStart).Seconds())
-
 				update := LeaderboardUpdate{
 					Data: jsonData,
 					Hash: currentHash,
 				}
-
 				lb.broadcastToAllClients(update)
 			}
 		case <-lb.ctx.Done():
@@ -202,6 +203,7 @@ func StreamLeaderboard(c *gin.Context) {
 		case update, ok := <-channel:
 			if !ok {
 				// channel closed
+				config.Error("Channel found closed on update", map[string]any{})
 				return
 			}
 			fmt.Fprintf(c.Writer, "data: %s\n\n", update.Data)
@@ -209,7 +211,7 @@ func StreamLeaderboard(c *gin.Context) {
 			metrics.SSEMessagesSent.Inc()
 		case <-c.Request.Context().Done():
 			metrics.DroppedSSEConnections.Inc()
-			config.Info("Closed SSE conn", map[string]any{"open": metrics.ActiveSSEConnections})
+			config.Info("Closed SSE conn", map[string]any{})
 			return
 		}
 	}

--- a/src/backend/submit_game.go
+++ b/src/backend/submit_game.go
@@ -10,6 +10,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// TODO: size limits of result message and authentication for game servers needs to be set up
+
 func SubmitGameResults(c *gin.Context) {
 	var game models.GameResult
 	if err := c.ShouldBindJSON(&game); err != nil {

--- a/src/redisclient/redis.go
+++ b/src/redisclient/redis.go
@@ -62,13 +62,11 @@ func GetTopNPlayers(ctx context.Context, key string, n int64) ([]redis.Z, error)
 
 	scores, err := redisClient.ZRevRangeWithScores(ctx, key, 0, n-1).Result()
 
-	metrics.RedisPayloadSize.Observe(float64(len(scores)))
-    metrics.RedisLatency.Observe(time.Since(start).Seconds())
-    
-
-	if err == redis.Nil {
+	if err == nil {
 		return nil, config.Error("Failed to fetch top n players", map[string]any{})
 	}
+	metrics.RedisPayloadSize.Observe(float64(len(scores)))
+	metrics.RedisLatency.Observe(time.Since(start).Seconds())
 	return scores, nil
 }
 

--- a/src/redisclient/redis.go
+++ b/src/redisclient/redis.go
@@ -32,9 +32,6 @@ func InitRedis() {
 
 func UpdateLeaderboard(ctx context.Context, player1ID, player2ID string, result int) error {
 	start := time.Now()
-	defer func() {
-		metrics.RedisLatency.Observe(time.Since(start).Seconds())
-	}()
 	updateStart := time.Now()
 	switch result {
 	case 0:
@@ -55,15 +52,13 @@ func UpdateLeaderboard(ctx context.Context, player1ID, player2ID string, result 
 				"result":    result,
 			})
 	}
+	metrics.RedisLatency.Observe(time.Since(start).Seconds())
 	metrics.LeaderboardUpdateDuration.Observe(time.Since(updateStart).Seconds())
 	return nil
 }
 
 func GetTopNPlayers(ctx context.Context, key string, n int64) ([]redis.Z, error) {
 	start := time.Now()
-	defer func() {
-		metrics.RedisLatency.Observe(time.Since(start).Seconds())
-	}()
 
 	scores, err := redisClient.ZRevRangeWithScores(ctx, key, 0, n-1).Result()
 

--- a/src/redisclient/redis.go
+++ b/src/redisclient/redis.go
@@ -74,14 +74,12 @@ func GetTopNPlayers(ctx context.Context, key string, n int64) ([]redis.Z, error)
 
 func GetPlayerScore(ctx context.Context, key string, playerID string) (int64, float64, error) {
 	start := time.Now()
-	defer func() {
-		metrics.RedisLatency.Observe(time.Since(start).Seconds())
-	}()
 
 	player_info, err := redisClient.ZRankWithScore(ctx, key, playerID).Result()
 	if err == redis.Nil {
 		config.Error("Something went wrong while getting player stats", map[string]any{"player_id": playerID, "Error": err})
 	}
+	metrics.RedisLatency.Observe(time.Since(start).Seconds())
 	rank := player_info.Rank
 	score := player_info.Score
 	return rank, score, err


### PR DESCRIPTION
This PR aims to address the issue of backpressure (filled SSE channels of slow clients) by draining them when encountered, then pushing latest update. This would not disturb the overall flow of leaderboard, as clients need latest updates most, intermediate updates and backfills do not matter.

Additional improvements done to deduplication - replace string substitution with JSON marshaling (deterministic - hash results will always be same). This also has the added benefit of not having to do a JSON marshaling if change was encountered.

Other small changes include updating redis client metrics, a comment on the submit_game file