### PR TITLE
fix/channel-management: add heartbeats, error handling for SSE writes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ server:
   port: 8080
   broadcast_buffer_size: 100
   polling_interval_seconds: 5
+  heartbeat_interval_seconds: 20
 leaderboard:
   update_interval_secs: 5
   top_players_limit: 10

--- a/grafana/dashboards/leaderboard.json
+++ b/grafana/dashboards/leaderboard.json
@@ -69,7 +69,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -86,7 +87,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 9,
+      "id": 10,
       "options": {
         "legend": {
           "calcs": [],
@@ -100,21 +101,17 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.0.1",
+      "pluginVersion": "12.2.0-16818804881",
       "targets": [
         {
-          "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "go_memstats_heap_inuse_bytes",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
+          "expr": "filled_sse_channels",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "A"
         }
       ],
-      "title": "Go heap bytes in use",
+      "title": "Filled SSE channels",
       "type": "timeseries"
     },
     {
@@ -165,7 +162,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -196,7 +194,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.0.1",
+      "pluginVersion": "12.2.0-16818804881",
       "targets": [
         {
           "disableTextWrap": false,
@@ -261,7 +259,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -292,7 +291,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.0.1",
+      "pluginVersion": "12.2.0-16818804881",
       "targets": [
         {
           "disableTextWrap": false,
@@ -307,6 +306,204 @@
         }
       ],
       "title": "Goroutines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "leaderboard_ds"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0-16818804881",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "go_memstats_heap_inuse_bytes",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Go heap bytes in use",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "leaderboard_ds"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0-16818804881",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "leaderboard_ds"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "game_submissions_total",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Total game submissions",
       "type": "timeseries"
     },
     {
@@ -338,7 +535,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -353,83 +551,6 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
-      },
-      "id": 4,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.1",
-      "targets": [
-        {
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "redis_latency_seconds_bucket",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Redis latency hist",
-      "type": "histogram"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "leaderboard_ds"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineWidth": 1,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
         "y": 16
       },
       "id": 6,
@@ -446,7 +567,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.0.1",
+      "pluginVersion": "12.2.0-16818804881",
       "targets": [
         {
           "disableTextWrap": false,
@@ -511,7 +632,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -525,8 +647,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 16
+        "x": 0,
+        "y": 24
       },
       "id": 5,
       "options": {
@@ -542,7 +664,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.0.1",
+      "pluginVersion": "12.2.0-16818804881",
       "targets": [
         {
           "disableTextWrap": false,
@@ -557,6 +679,177 @@
         }
       ],
       "title": "Dropped SSE connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "leaderboard_ds"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0-16818804881",
+      "targets": [
+        {
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "redis_latency_seconds_bucket",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Redis latency hist",
+      "type": "histogram"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "leaderboard_ds"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0-16818804881",
+      "targets": [
+        {
+          "editorMode": "builder",
+          "expr": "go_gc_gomemlimit_bytes",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Go GC memory limit bytes",
       "type": "timeseries"
     },
     {
@@ -607,7 +900,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -621,8 +915,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 24
+        "x": 12,
+        "y": 32
       },
       "id": 3,
       "options": {
@@ -638,7 +932,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.0.1",
+      "pluginVersion": "12.2.0-16818804881",
       "targets": [
         {
           "disableTextWrap": false,
@@ -703,7 +997,101 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.0-16818804881",
+      "targets": [
+        {
+          "editorMode": "builder",
+          "expr": "go_memstats_alloc_bytes_total",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Go memstats alloc bytes total",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "leaderboard_ds"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
               },
               {
                 "color": "red",
@@ -718,9 +1106,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 40
       },
-      "id": 1,
+      "id": 12,
       "options": {
         "legend": {
           "calcs": [],
@@ -734,25 +1122,17 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.0.1",
+      "pluginVersion": "12.2.0-16818804881",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "leaderboard_ds"
-          },
-          "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "game_submissions_total",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
+          "expr": "go_gc_duration_seconds",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "A",
-          "useBackend": false
+          "refId": "A"
         }
       ],
-      "title": "Total game submissions",
+      "title": "GC duration seconds",
       "type": "timeseries"
     }
   ],
@@ -764,12 +1144,12 @@
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
   "title": "Leaderboard-dash",
   "uid": "e6e4b7ce-41d5-409d-ac82-b04048b14015",
-  "version": 6
+  "version": 7
 }

--- a/src/backend/sse.go
+++ b/src/backend/sse.go
@@ -208,17 +208,32 @@ func StreamLeaderboard(c *gin.Context) {
 	client, channel := broadcaster.AddClient()
 	defer broadcaster.RemoveClient(client)
 
+	heartbeatTicker := time.NewTicker(20 * time.Second)
+	defer heartbeatTicker.Stop()
+
 	for {
 		select {
 		case update, ok := <-channel:
 			if !ok {
-				// channel closed
-				config.Info("Channel found closed on update", map[string]any{})
+				config.Info("Channel found closed on update", map[string]any{"client ID": client.ID})
 				return
 			}
-			fmt.Fprintf(c.Writer, "data: %s\n\n", update.Data)
+			_, err := fmt.Fprintf(c.Writer, "data: %s\n\n", update.Data)
+			if err != nil {
+				metrics.DroppedSSEConnections.Inc()
+				config.Info("Abruptly closed SSE conn", map[string]any{"Error": err, "client ID": client.ID})
+				return
+			}
 			c.Writer.Flush()
 			metrics.SSEMessagesSent.Inc()
+		case <-heartbeatTicker.C:
+			_, err := fmt.Fprintf(c.Writer, ": ping\n\n")
+			if err != nil {
+				metrics.DroppedSSEConnections.Inc()
+				config.Info("Heartbeat failed, closing SSE conn", map[string]any{"client ID": client.ID})
+				return
+			}
+			c.Writer.Flush()
 		case <-c.Request.Context().Done():
 			metrics.DroppedSSEConnections.Inc()
 			config.Info("Closed SSE conn", map[string]any{"client ID": client.ID})

--- a/src/backend/sse.go
+++ b/src/backend/sse.go
@@ -199,6 +199,7 @@ func StreamLeaderboard(c *gin.Context) {
 	c.Writer.Header().Set("Content-Type", "text/event-stream")
 	c.Writer.Header().Set("Cache-Control", "no-cache")
 	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Header().Set("X-Accel-Buffering", "no")
 	c.Writer.Flush()
 
 	metrics.ActiveSSEConnections.Inc()
@@ -230,7 +231,7 @@ func StreamLeaderboard(c *gin.Context) {
 			_, err := fmt.Fprintf(c.Writer, ": ping\n\n")
 			if err != nil {
 				metrics.DroppedSSEConnections.Inc()
-				config.Info("Heartbeat failed, closing SSE conn", map[string]any{"client ID": client.ID})
+				config.Info("Heartbeat failed, closing SSE conn", map[string]any{"Error": err, "client ID": client.ID})
 				return
 			}
 			c.Writer.Flush()

--- a/src/backend/sse.go
+++ b/src/backend/sse.go
@@ -36,7 +36,7 @@ type LeaderboardBroadcaster struct {
 }
 
 // CreateLeaderboardBroadcaster creates and returns a new LeaderboardBroadcaster.
-// 
+//
 // The returned broadcaster has an internal cancelable context, an initialized
 // client map, and a WaitGroup entry for a background goroutine that polls for
 // leaderboard changes. A background goroutine running detectLeaderboardChanges
@@ -141,7 +141,7 @@ func (lb *LeaderboardBroadcaster) broadcastToAllClients(update LeaderboardUpdate
 	}
 }
 
-// package level var
+// TODO: change to dependency injection
 var broadcaster *LeaderboardBroadcaster
 
 func SetBroadcaster(b *LeaderboardBroadcaster) {
@@ -208,7 +208,7 @@ func StreamLeaderboard(c *gin.Context) {
 	client, channel := broadcaster.AddClient()
 	defer broadcaster.RemoveClient(client)
 
-	heartbeatTicker := time.NewTicker(20 * time.Second)
+	heartbeatTicker := time.NewTicker(time.Duration(config.AppConfig.Server.HeartbeatIntervalSeconds) * time.Second)
 	defer heartbeatTicker.Stop()
 
 	for {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 		Host                   string `yaml:"host"`
 		BroadcastBufferSize    int    `yaml:"broadcast_buffer_size"`
 		PollingIntervalSeconds int    `yaml:"polling_interval_seconds"`
+		HeartbeatIntervalSeconds int `yaml:"heartbeat_interval_seconds"`
 	} `yaml:"server"`
 
 	Leaderboard struct {

--- a/src/redisclient/redis.go
+++ b/src/redisclient/redis.go
@@ -28,24 +28,28 @@ func InitRedis() {
 		config.Error("Failed to connect to redis client, retrying", map[string]any{"Error": err})
 		time.Sleep(2 * time.Second)
 	}
-	config.Fatal("Could not connect to redis client after max retries", map[string]any{"Tried":maxRetries})
+	config.Fatal("Could not connect to redis client after max retries", map[string]any{"Tried": maxRetries})
 }
 
 // The function also observes RedisLatency and LeaderboardUpdateDuration metrics after performing the update.
 func UpdateLeaderboard(ctx context.Context, player1ID, player2ID string, result int) error {
 	start := time.Now()
 	updateStart := time.Now()
+	var err error
+
 	switch result {
 	case 0:
 		//player 1 wins
-		redisClient.ZIncrBy(ctx, "leaderboard", 1.0, player1ID)
+		err = redisClient.ZIncrBy(ctx, "leaderboard", 1.0, player1ID).Err()
 	case 1:
 		//player 2 wins
-		redisClient.ZIncrBy(ctx, "leaderboard", 1.0, player2ID)
+		err = redisClient.ZIncrBy(ctx, "leaderboard", 1.0, player2ID).Err()
 	case 2:
 		//draw due to any reason
-		redisClient.ZIncrBy(ctx, "leaderboard", 0.5, player1ID)
-		redisClient.ZIncrBy(ctx, "leaderboard", 0.5, player2ID)
+		pipe := redisClient.Pipeline()
+		pipe.ZIncrBy(ctx, "leaderboard", 0.5, player1ID)
+		pipe.ZIncrBy(ctx, "leaderboard", 0.5, player2ID)
+		_, err = pipe.Exec(ctx)
 	default:
 		return config.Error("Invalid game result, did not update leaderboard",
 			map[string]any{
@@ -56,6 +60,11 @@ func UpdateLeaderboard(ctx context.Context, player1ID, player2ID string, result 
 	}
 	metrics.RedisLatency.Observe(time.Since(start).Seconds())
 	metrics.LeaderboardUpdateDuration.Observe(time.Since(updateStart).Seconds())
+
+	if err != nil {
+		return config.Error("Failed to update leaderboard", map[string]any{"Error": err})
+	}
+
 	return nil
 }
 
@@ -66,13 +75,11 @@ func GetTopNPlayers(ctx context.Context, key string, n int64) ([]redis.Z, error)
 	start := time.Now()
 
 	scores, err := redisClient.ZRevRangeWithScores(ctx, key, 0, n-1).Result()
-
+	metrics.RedisLatency.Observe(time.Since(start).Seconds())
 	if err != nil {
-		metrics.RedisLatency.Observe(time.Since(start).Seconds())
-		return nil, config.Error("Failed to fetch top n players", map[string]any{})
+		return nil, config.Error("Failed to fetch top n players", map[string]any{"Error": err})
 	}
 	metrics.RedisPayloadSize.Observe(float64(len(scores)))
-	metrics.RedisLatency.Observe(time.Since(start).Seconds())
 	return scores, nil
 }
 
@@ -85,12 +92,13 @@ func GetPlayerScore(ctx context.Context, key string, playerID string) (int64, fl
 	start := time.Now()
 
 	player_info, err := redisClient.ZRankWithScore(ctx, key, playerID).Result()
+	metrics.RedisLatency.Observe(time.Since(start).Seconds())
+	if err != redis.Nil {
+		return 0, 0, redis.Nil
+	}
 	if err != nil {
-		metrics.RedisLatency.Observe(time.Since(start).Seconds())
 		return 0, 0, config.Error("Something went wrong while getting player stats", map[string]any{"player_id": playerID, "Error": err})
 	}
-	metrics.RedisLatency.Observe(time.Since(start).Seconds())
-	rank := player_info.Rank
-	score := player_info.Score
-	return rank, score, nil
+
+	return player_info.Rank, player_info.Score, nil
 }

--- a/src/redisclient/redis.go
+++ b/src/redisclient/redis.go
@@ -2,6 +2,7 @@ package redisclient
 
 import (
 	"context"
+	"errors"
 	"leaderboard/src/config"
 	"leaderboard/src/metrics"
 	"time"
@@ -20,12 +21,14 @@ func InitRedis() {
 			DB:       config.AppConfig.Redis.DB,
 		})
 
-		_, err := redisClient.Ping(context.Background()).Result()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_, err := redisClient.Ping(ctx).Result()
+		cancel()
 		// keep retrying until redis is connected, fatal otherwise
 		if err == nil {
 			return
 		}
-		config.Error("Failed to connect to redis client, retrying", map[string]any{"Error": err})
+		config.Error("Failed to connect to redis client, retrying", map[string]any{"Error": err, "tried": i + 1, "maxRetries": maxRetries})
 		time.Sleep(2 * time.Second)
 	}
 	config.Fatal("Could not connect to redis client after max retries", map[string]any{"Tried": maxRetries})
@@ -62,7 +65,7 @@ func UpdateLeaderboard(ctx context.Context, player1ID, player2ID string, result 
 	metrics.LeaderboardUpdateDuration.Observe(time.Since(updateStart).Seconds())
 
 	if err != nil {
-		return config.Error("Failed to update leaderboard", map[string]any{"Error": err})
+		return config.Error("Failed to update leaderboard", map[string]any{"Error": err, "Player1 ID": player1ID, "Player2 ID": player2ID, "Result": result})
 	}
 
 	return nil
@@ -86,14 +89,16 @@ func GetTopNPlayers(ctx context.Context, key string, n int64) ([]redis.Z, error)
 // GetPlayerScore returns the leaderboard rank and score for the given player ID in the specified sorted set key.
 //
 // The function queries Redis for the member's rank and score and observes the Redis latency metric before returning.
-// If the player is not present, Redis returns redis.Nil; in that case the error will be redis.Nil and the returned
-// rank and score will be zero. Any other Redis error is returned to the caller as well.
+// If the player is not present, Redis returns redis.Nil; in that case the 0,0, nil is returned.
+// Any other Redis error is returned to the caller.
 func GetPlayerScore(ctx context.Context, key string, playerID string) (int64, float64, error) {
 	start := time.Now()
 
 	player_info, err := redisClient.ZRankWithScore(ctx, key, playerID).Result()
 	metrics.RedisLatency.Observe(time.Since(start).Seconds())
-	if err != redis.Nil {
+	if errors.Is(err, redis.Nil) {
+		//player not found
+		config.Info("Player not found", map[string]any{"Player ID": playerID, "source": "GetPlayerScore"})
 		return 0, 0, redis.Nil
 	}
 	if err != nil {

--- a/src/redisclient/redis.go
+++ b/src/redisclient/redis.go
@@ -21,6 +21,7 @@ func InitRedis() {
 		})
 
 		_, err := redisClient.Ping(context.Background()).Result()
+		// keep retrying until redis is connected, fatal otherwise
 		if err == nil {
 			return
 		}
@@ -46,6 +47,7 @@ func UpdateLeaderboard(ctx context.Context, player1ID, player2ID string, result 
 		redisClient.ZIncrBy(ctx, "leaderboard", 0.5, player1ID)
 		redisClient.ZIncrBy(ctx, "leaderboard", 0.5, player2ID)
 	default:
+		// ? is this incorrect?
 		return config.Error("Invalid game result, did not update leaderboard",
 			map[string]any{
 				"player1ID": player1ID,
@@ -66,7 +68,8 @@ func GetTopNPlayers(ctx context.Context, key string, n int64) ([]redis.Z, error)
 
 	scores, err := redisClient.ZRevRangeWithScores(ctx, key, 0, n-1).Result()
 
-	if err == nil {
+	if err != nil {
+		metrics.RedisLatency.Observe(time.Since(start).Seconds())
 		return nil, config.Error("Failed to fetch top n players", map[string]any{})
 	}
 	metrics.RedisPayloadSize.Observe(float64(len(scores)))
@@ -75,7 +78,7 @@ func GetTopNPlayers(ctx context.Context, key string, n int64) ([]redis.Z, error)
 }
 
 // GetPlayerScore returns the leaderboard rank and score for the given player ID in the specified sorted set key.
-// 
+//
 // The function queries Redis for the member's rank and score and observes the Redis latency metric before returning.
 // If the player is not present, Redis returns redis.Nil; in that case the error will be redis.Nil and the returned
 // rank and score will be zero. Any other Redis error is returned to the caller as well.
@@ -83,11 +86,12 @@ func GetPlayerScore(ctx context.Context, key string, playerID string) (int64, fl
 	start := time.Now()
 
 	player_info, err := redisClient.ZRankWithScore(ctx, key, playerID).Result()
-	if err == redis.Nil {
-		config.Error("Something went wrong while getting player stats", map[string]any{"player_id": playerID, "Error": err})
+	if err != nil {
+		metrics.RedisLatency.Observe(time.Since(start).Seconds())
+		return 0, 0, config.Error("Something went wrong while getting player stats", map[string]any{"player_id": playerID, "Error": err})
 	}
 	metrics.RedisLatency.Observe(time.Since(start).Seconds())
 	rank := player_info.Rank
 	score := player_info.Score
-	return rank, score, err
+	return rank, score, nil
 }

--- a/src/redisclient/redis.go
+++ b/src/redisclient/redis.go
@@ -28,7 +28,7 @@ func InitRedis() {
 		config.Error("Failed to connect to redis client, retrying", map[string]any{"Error": err})
 		time.Sleep(2 * time.Second)
 	}
-	config.Fatal("Could not connect to redis client after 10 retries", map[string]any{})
+	config.Fatal("Could not connect to redis client after max retries", map[string]any{"Tried":maxRetries})
 }
 
 // The function also observes RedisLatency and LeaderboardUpdateDuration metrics after performing the update.
@@ -47,7 +47,6 @@ func UpdateLeaderboard(ctx context.Context, player1ID, player2ID string, result 
 		redisClient.ZIncrBy(ctx, "leaderboard", 0.5, player1ID)
 		redisClient.ZIncrBy(ctx, "leaderboard", 0.5, player2ID)
 	default:
-		// ? is this incorrect?
 		return config.Error("Invalid game result, did not update leaderboard",
 			map[string]any{
 				"player1ID": player1ID,
@@ -62,7 +61,7 @@ func UpdateLeaderboard(ctx context.Context, player1ID, player2ID string, result 
 
 // GetTopNPlayers returns up to n entries from the sorted set stored at key ordered by highest score first.
 // It calls Redis ZRevRangeWithScores to fetch the top N members with their scores and returns the resulting []redis.Z.
-// Note: due to inverted error handling in this implementation, a nil error from Redis is treated as a failure (the function returns a non-nil error), while a non-nil Redis error will cause the function to record metrics and return the fetched scores.
+// On success, returns top N scores, sorted in reverse order (highest first). On failure, records error, returns.
 func GetTopNPlayers(ctx context.Context, key string, n int64) ([]redis.Z, error) {
 	start := time.Now()
 

--- a/src/redisclient/redis.go
+++ b/src/redisclient/redis.go
@@ -28,7 +28,7 @@ func InitRedis() {
 		if err == nil {
 			return
 		}
-		config.Error("Failed to connect to redis client, retrying", map[string]any{"Error": err, "tried": i + 1, "maxRetries": maxRetries})
+		config.Error("Failed to connect to redis client, retrying", map[string]any{"Error": err, "attempted": i + 1, "maxRetries": maxRetries})
 		time.Sleep(2 * time.Second)
 	}
 	config.Fatal("Could not connect to redis client after max retries", map[string]any{"Tried": maxRetries})
@@ -65,7 +65,7 @@ func UpdateLeaderboard(ctx context.Context, player1ID, player2ID string, result 
 	metrics.LeaderboardUpdateDuration.Observe(time.Since(updateStart).Seconds())
 
 	if err != nil {
-		return config.Error("Failed to update leaderboard", map[string]any{"Error": err, "Player1 ID": player1ID, "Player2 ID": player2ID, "Result": result})
+		return config.Error("Failed to update leaderboard", map[string]any{"Error": err, "player1ID": player1ID, "player2ID": player2ID, "Result": result})
 	}
 
 	return nil
@@ -94,16 +94,16 @@ func GetTopNPlayers(ctx context.Context, key string, n int64) ([]redis.Z, error)
 func GetPlayerScore(ctx context.Context, key string, playerID string) (int64, float64, error) {
 	start := time.Now()
 
-	player_info, err := redisClient.ZRankWithScore(ctx, key, playerID).Result()
+	playerInfo, err := redisClient.ZRankWithScore(ctx, key, playerID).Result()
 	metrics.RedisLatency.Observe(time.Since(start).Seconds())
 	if errors.Is(err, redis.Nil) {
 		//player not found
 		config.Info("Player not found", map[string]any{"Player ID": playerID, "source": "GetPlayerScore"})
-		return 0, 0, redis.Nil
+		return 0, 0, nil
 	}
 	if err != nil {
 		return 0, 0, config.Error("Something went wrong while getting player stats", map[string]any{"player_id": playerID, "Error": err})
 	}
 
-	return player_info.Rank, player_info.Score, nil
+	return playerInfo.Rank, playerInfo.Score, nil
 }


### PR DESCRIPTION
Add heartbeats to know if channels are up.
Add better error handling for writes in SSE.
Fix error handling bug in redis.go, add early return.
Use config vars for heatbeat interval.
Improve grafana dashboard.
