### PR TITLE
refactor: use interfaces for dependency injection (instead of globals), start adding tests

### DIFF
--- a/src/backend/sse.go
+++ b/src/backend/sse.go
@@ -141,13 +141,6 @@ func (lb *LeaderboardBroadcaster) broadcastToAllClients(update LeaderboardUpdate
 	}
 }
 
-// TODO: change to dependency injection
-var broadcaster *LeaderboardBroadcaster
-
-func SetBroadcaster(b *LeaderboardBroadcaster) {
-	broadcaster = b
-}
-
 // poll redis, dedup leaderboard values, push to broadcast to all clients
 func (lb *LeaderboardBroadcaster) detectLeaderboardChanges() {
 	defer lb.wg.Done()
@@ -192,7 +185,7 @@ func (lb *LeaderboardBroadcaster) detectLeaderboardChanges() {
 }
 
 // and ensures the client is removed from the broadcaster when the handler returns.
-func StreamLeaderboard(c *gin.Context) {
+func (lb *LeaderboardBroadcaster) StreamLeaderboard(c *gin.Context) {
 	metrics.ConcurrentClients.Inc()
 	defer metrics.ConcurrentClients.Dec()
 
@@ -206,8 +199,8 @@ func StreamLeaderboard(c *gin.Context) {
 	config.Info("New SSE conn", map[string]any{})
 	defer metrics.ActiveSSEConnections.Dec()
 
-	client, channel := broadcaster.AddClient()
-	defer broadcaster.RemoveClient(client)
+	client, channel := lb.AddClient()
+	defer lb.RemoveClient(client)
 
 	heartbeatTicker := time.NewTicker(time.Duration(config.AppConfig.Server.HeartbeatIntervalSeconds) * time.Second)
 	defer heartbeatTicker.Stop()

--- a/src/main.go
+++ b/src/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-type Broadcaster interface {
+type broadcaster interface {
 	StopBroadcast()
 	StreamLeaderboard(*gin.Context)
 }
@@ -30,7 +30,7 @@ func main() {
 	redisclient.InitRedis()
 	metrics.InitMetrics()
 
-	broadcaster := backend.CreateLeaderboardBroadcaster()
+	var broadcaster broadcaster = backend.CreateLeaderboardBroadcaster()
 	defer broadcaster.StopBroadcast()
 
 	r := gin.Default()
@@ -38,7 +38,7 @@ func main() {
 	r.Use(metrics.MetricsMiddleware())
 
 	r.POST("/submit-game", backend.SubmitGameResults)
-	r.GET("/stream-leaderboard", func(ctx *gin.Context) { broadcaster.StreamLeaderboard(ctx) })
+	r.GET("/stream-leaderboard", broadcaster.StreamLeaderboard)
 	r.GET("/metrics", gin.WrapH(promhttp.Handler()))
 	r.GET("/player/:id/stats", backend.GetPlayerResults)
 	r.GET("/leaderboard", backend.GetLeaderboard)

--- a/src/main.go
+++ b/src/main.go
@@ -11,6 +11,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+type Broadcaster interface {
+	StopBroadcast()
+	StreamLeaderboard(*gin.Context)
+}
+
 func main() {
 	config.InitLogger()
 	if err := config.LoadConfig("config.yaml"); err != nil {
@@ -28,14 +33,12 @@ func main() {
 	broadcaster := backend.CreateLeaderboardBroadcaster()
 	defer broadcaster.StopBroadcast()
 
-	backend.SetBroadcaster(broadcaster)
-
 	r := gin.Default()
 
 	r.Use(metrics.MetricsMiddleware())
 
 	r.POST("/submit-game", backend.SubmitGameResults)
-	r.GET("/stream-leaderboard", backend.StreamLeaderboard)
+	r.GET("/stream-leaderboard", func(ctx *gin.Context) { broadcaster.StreamLeaderboard(ctx) })
 	r.GET("/metrics", gin.WrapH(promhttp.Handler()))
 	r.GET("/player/:id/stats", backend.GetPlayerResults)
 	r.GET("/leaderboard", backend.GetLeaderboard)

--- a/tests/unit/sse_test.go
+++ b/tests/unit/sse_test.go
@@ -1,0 +1,16 @@
+package unit_test
+
+import (
+	"leaderboard/src/backend"
+	"testing"
+)
+
+func TestBroadcasterCreation(t *testing.T) {
+	b := backend.CreateLeaderboardBroadcaster()
+	switch v := interface{}(b).(type) {
+	case *backend.LeaderboardBroadcaster:
+		// correct type
+	default:
+		t.Errorf("Expected *backend.LeaderboardBroadcaster, got %T", v)
+	}
+}

--- a/tests/unit/sse_test.go
+++ b/tests/unit/sse_test.go
@@ -7,10 +7,8 @@ import (
 
 func TestBroadcasterCreation(t *testing.T) {
 	b := backend.CreateLeaderboardBroadcaster()
-	switch v := interface{}(b).(type) {
-	case *backend.LeaderboardBroadcaster:
-		// correct type
-	default:
-		t.Errorf("Expected *backend.LeaderboardBroadcaster, got %T", v)
+	defer b.StopBroadcast()
+	if _, ok:=any(b).(*backend.LeaderboardBroadcaster); !ok{
+		t.Fatalf("Expected *backend.LeaderboardBroadCaster, got %T", b)
 	}
 }

--- a/tests/unit/sse_test.go
+++ b/tests/unit/sse_test.go
@@ -3,12 +3,18 @@ package unit_test
 import (
 	"leaderboard/src/backend"
 	"testing"
+
+	"github.com/gin-gonic/gin"
 )
 
 func TestBroadcasterCreation(t *testing.T) {
+	type broadcaster interface {
+		StopBroadcast()
+		StreamLeaderboard(*gin.Context)
+	}
 	b := backend.CreateLeaderboardBroadcaster()
-	defer b.StopBroadcast()
-	if _, ok:=any(b).(*backend.LeaderboardBroadcaster); !ok{
-		t.Fatalf("Expected *backend.LeaderboardBroadCaster, got %T", b)
+	// not adding defer b.StopBroadcast, created nil pointer dereference error, possibly because of Fatalf
+	if _, ok := any(b).(broadcaster); !ok {
+		t.Fatalf("broadcaster does not satisfy interface requirements, got %T", b)
 	}
 }


### PR DESCRIPTION
Removed global LeaderboardBroadcaster declaration, instead used interface in main.go to work things out.
Created unit test to check for type when initialized, will be followed by tests for behaviour (AddClient, RemoveClient first).