### PR TITLE
Add graceful shutdown

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,7 @@ server:
   broadcast_buffer_size: 100
   polling_interval_seconds: 5
   heartbeat_interval_seconds: 20
+  graceful_shutdown_timeout_seconds: 30
 leaderboard:
   update_interval_secs: 5
   top_players_limit: 10

--- a/src/backend/sse.go
+++ b/src/backend/sse.go
@@ -78,8 +78,8 @@ func CreateLeaderboardBroadcaster(store interfaces.LeaderboardStore, cfg *Broadc
 	return lb, nil
 }
 
-// TODO: should have an endpoint, with proper auth - admin only
-// TODO: how to use this along with graceful shutdown
+// Removes all client connections, cleans up client channels, stopping the broadcast
+// currently being used only with the graceful shutdown option in main.go
 func (lb *LeaderboardBroadcaster) StopBroadcast() {
 	lb.cancel()
 	lb.wg.Wait()
@@ -111,7 +111,7 @@ func (lb *LeaderboardBroadcaster) AddClient() (*Client, <-chan LeaderboardUpdate
 	return client, client.channel
 }
 
-// remove specific client channel - closed connection
+// Remove a specific client which closed its connection to the server
 func (lb *LeaderboardBroadcaster) RemoveClient(client *Client) {
 	lb.clientsMutex.Lock()
 	defer lb.clientsMutex.Unlock()
@@ -123,19 +123,19 @@ func (lb *LeaderboardBroadcaster) RemoveClient(client *Client) {
 	}
 }
 
-// counts the active number of clients, replace later with a field in broadcaster struct
+// Counts the active number of clients, replace later with a field in broadcaster struct
 func (lb *LeaderboardBroadcaster) CountClients() int {
 	lb.clientsMutex.RLock()
 	defer lb.clientsMutex.RUnlock()
 	return len(lb.clients)
 }
 
-// to be used only for testing purposes
+// Force sends an update to all clients, intended for testing use
 func (lb *LeaderboardBroadcaster) BroadcastNow(update *LeaderboardUpdate) {
 	lb.broadcastToAllClients(update)
 }
 
-// broadcastToAllClients sends an update to all connected clients
+// Sends an update to all connected clients
 func (lb *LeaderboardBroadcaster) broadcastToAllClients(update *LeaderboardUpdate) {
 	lb.clientsMutex.RLock()
 
@@ -177,7 +177,7 @@ func (lb *LeaderboardBroadcaster) broadcastToAllClients(update *LeaderboardUpdat
 	}
 }
 
-// poll redis, dedup leaderboard values, push to broadcast to all clients
+// Poll redis, dedup leaderboard state, push to broadcast to all clients
 func (lb *LeaderboardBroadcaster) detectLeaderboardChanges(ticks <-chan time.Time) {
 	defer lb.wg.Done()
 
@@ -218,7 +218,7 @@ func (lb *LeaderboardBroadcaster) detectLeaderboardChanges(ticks <-chan time.Tim
 	}
 }
 
-// handler for /stream-leaderboard
+// Handler for /stream-leaderboard endpoint
 func (lb *LeaderboardBroadcaster) StreamLeaderboard(c *gin.Context) {
 	c.Writer.Header().Set("Content-Type", "text/event-stream")
 	c.Writer.Header().Set("Cache-Control", "no-cache")

--- a/src/backend/sse.go
+++ b/src/backend/sse.go
@@ -90,6 +90,7 @@ func (lb *LeaderboardBroadcaster) StopBroadcast() {
 	for _, client := range lb.clients {
 		client.cancel()
 		client.closeOnce.Do(func() { close(client.channel) })
+		delete(lb.clients, client.ID)
 	}
 }
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -18,11 +18,12 @@ type Config struct {
 	} `yaml:"redis"`
 
 	Server struct {
-		Port                   int    `yaml:"port"`
-		Host                   string `yaml:"host"`
-		BroadcastBufferSize    int    `yaml:"broadcast_buffer_size"`
-		PollingIntervalSeconds int    `yaml:"polling_interval_seconds"`
-		HeartbeatIntervalSeconds int `yaml:"heartbeat_interval_seconds"`
+		Port                           int    `yaml:"port"`
+		Host                           string `yaml:"host"`
+		BroadcastBufferSize            int    `yaml:"broadcast_buffer_size"`
+		PollingIntervalSeconds         int    `yaml:"polling_interval_seconds"`
+		HeartbeatIntervalSeconds       int    `yaml:"heartbeat_interval_seconds"`
+		GracefulShutdownTimeoutSeconds int    `yaml:"graceful_shutdown_timeout_seconds"`
 	} `yaml:"server"`
 
 	Leaderboard struct {

--- a/src/main.go
+++ b/src/main.go
@@ -49,7 +49,6 @@ func main() {
 	if err != nil {
 		config.Fatal("incorrect config passed to leaderboard constructor", map[string]any{"err": err})
 	}
-	defer lb.StopBroadcast()
 
 	r := gin.Default()
 

--- a/src/main.go
+++ b/src/main.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"leaderboard/src/backend"
 	"leaderboard/src/config"
 	"leaderboard/src/metrics"
 	"leaderboard/src/redisclient"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -57,7 +63,33 @@ func main() {
 
 	address := fmt.Sprintf("%s:%d", config.AppConfig.Server.Host, config.AppConfig.Server.Port)
 
-	if err := r.Run(address); err != nil {
-		config.Fatal("failed to start server", map[string]any{"err": err})
+	srv := &http.Server{
+		Addr:    address,
+		Handler: r,
 	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			config.Fatal("listen error", map[string]any{"err": err})
+		}
+	}()
+
+	// Wait for interrupt signal to gracefully shutdown the server with a timeout
+	quit := make(chan os.Signal, 1)
+	// kill (no params) by default sends syscall.SIGTERM
+	// kill -2 is syscall.SIGINT
+	// kill -9 is syscall.SIGKILL but can't be caught, so don't need add it
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+	config.Info("Shutdown signal received, gracefully shutting down server...", map[string]any{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(config.AppConfig.Server.GracefulShutdownTimeoutSeconds))
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		config.Error("Server forced to shutdown", map[string]any{"err": err})
+	}
+
+	lb.StopBroadcast()
+	config.Info("Server exiting", map[string]any{})
 }

--- a/src/main.go
+++ b/src/main.go
@@ -78,12 +78,12 @@ func main() {
 	quit := make(chan os.Signal, 1)
 	// kill (no params) by default sends syscall.SIGTERM
 	// kill -2 is syscall.SIGINT
-	// kill -9 is syscall.SIGKILL but can't be caught, so don't need add it
+	// kill -9 is syscall.SIGKILL but can't be caught, so don't need it
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 	config.Info("Shutdown signal received, gracefully shutting down server...", map[string]any{})
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(config.AppConfig.Server.GracefulShutdownTimeoutSeconds))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(config.AppConfig.Server.GracefulShutdownTimeoutSeconds)*time.Second)
 	defer cancel()
 
 	if err := srv.Shutdown(ctx); err != nil {


### PR DESCRIPTION
Clears up resources (or attempts to) in case of a SIGTERM or SIGINT (syscalls to terminate a process, which are soft - do not require immediate termination).

Long awaited feature to ensure that memory and other resources are freed up when the program is terminated.

Follows gin's implementation using net/http and os and syscall libs, without use of external libs.

Added a config var for timeout of the ctx for shutdown (not really needed, can do with hardcoded value).