### PR TITLE
Add no metrics mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2026-04-07
+- Add no metrics mode using a config feature flag (don't register metrics, don't expose endpoint, no containers for prom and grafana)
+
 2025-12-27
 - Update README to latest state
 - Add a github actions workflow to run tests at each pull request to main

--- a/config.yaml
+++ b/config.yaml
@@ -13,3 +13,4 @@ server:
 leaderboard:
   update_interval_secs: 5
   top_players_limit: 10
+metrics_enabled: false

--- a/docker-compose.no-metrics.yml
+++ b/docker-compose.no-metrics.yml
@@ -1,0 +1,23 @@
+services:
+  leaderboard:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      - redis
+    environment:
+      - REDIS_ADDR=redis:6379
+    networks:
+      - internal
+
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+    networks:
+      - internal
+
+networks:
+  internal:

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -31,6 +31,8 @@ type Config struct {
 		TopPlayersLimit    int `yaml:"top_players_limit"`
 		CacheExpiryMins    int `yaml:"cache_expiry_mins"`
 	} `yaml:"leaderboard"`
+
+	MetricsEnabled bool `yaml:"metrics_enabled"`
 }
 
 var AppConfig *Config

--- a/src/main.go
+++ b/src/main.go
@@ -56,9 +56,11 @@ func main() {
 
 	r.POST("/submit-game", backend.SubmitGameResults(store))
 	r.GET("/stream-leaderboard", lb.StreamLeaderboard)
-	r.GET("/metrics", gin.WrapH(promhttp.Handler()))
 	r.GET("/player/:id/stats", backend.GetPlayerResults(store))
 	r.GET("/leaderboard", backend.GetLeaderboard(store, int64(config.AppConfig.Leaderboard.TopPlayersLimit)))
+	if config.AppConfig.MetricsEnabled{
+		r.GET("/metrics", gin.WrapH(promhttp.Handler()))
+	}
 
 	address := fmt.Sprintf("%s:%d", config.AppConfig.Server.Host, config.AppConfig.Server.Port)
 

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -138,6 +138,9 @@ var (
 )
 
 func InitMetrics() {
+	if !config.AppConfig.MetricsEnabled {
+		return
+	}
 	metrics := []prometheus.Collector{
 		GameSubmissions,
 		ActiveSSEConnections,


### PR DESCRIPTION
Prevents metrics from being sent out. This does it in multiple ways:
1. Metrics are not registered
2. Metrics endpoint is not registered
3. Prom and grafana containers (which scrape metrics endpoint) are removed in a separate compose file

The goal of this change is to reduce overhead on the main application, don't really need grafana and prom containers for everything.

Config changes are handled by a `metrics_enabled` flag in `config.yaml`, which is referenced in `config.go` and used by every other place as needed. The docker compose changes are made in an entirely new file - `docker-compose.no-metrics.yml` which can be used by `docker compose -f docker-compose.no-metrics.yml up`.