### PR TITLE
Add player id-name mapping, simulate writers for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+2026-06-15
+- Add match simulator that seeds randomly-named players and plays random concurrent matches, producing real write traffic (previously the system only had a reader path)
+- Store player ID - uname in a Redis hash, read APIs leaderboard, player-stats, and SSE reads now return both `player_id` and `name`
+- Add `POST /players` endpoint to register/rename a player
+- Add `Player` model + validation, batch name resolution (`GetPlayerNames` via HMGET) on leaderboard reads
+- Tests for player registration; update fake store and player-stats test for the name lookup
+
 2026-04-07
 - Add no metrics mode using a config feature flag (don't register metrics, don't expose endpoint, no containers for prom and grafana)
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ Content-Type: application/json
 }
 ```
 
+### Register Player 
+see `src/backend/player.go`
+
+Maps a player ID to a human-readable display name. The name is stored in a Redis hash and is returned alongside the player ID on all reads (this wasn't really needed from a backend pov, but good to see from a user's pov).
+
+```http
+POST /players
+Content-Type: application/json
+
+{
+  "player_id": "player1",
+  "name": "SwiftFalcon"
+}
+```
+
 ### Get Leaderboard
 see `src/backend/leaderboard.go`
 
@@ -82,13 +97,24 @@ Gets a snapshot of the leaderboard at that instant.
 GET /leaderboard
 ```
 
+```json
+[
+  {"player_id": "p_0009", "name": "BlazingFalcon9", "score": 5},
+  {"player_id": "p_0013", "name": "BraveTiger13", "score": 4.5}
+]
+```
+
 ### Get Player Stats
 see `src/backend/player.go`
 
-See the rank and score of a player by their id.
+See the rank, score, and name of a player by their id.
 
 ```http
 GET /player/:id/stats
+```
+
+```json
+{"player_id": "p_0000", "name": "IronFalcon0", "rank": 8, "score": 2.5}
 ```
 
 ### Stream Real-time Updates
@@ -98,6 +124,22 @@ Stream leaderboard updates periodically to the client connection.
 
 ```http
 GET /stream-leaderboard
+```
+
+## Match Simulator (write traffic)
+see `src/simulator/simulator.go`
+
+Previously the system only had a reader path (the SSE broadcaster polling Redis) and nothing wrote game results, so the leaderboard never updated. This is the most important feature for testing, on startup it seeds a pool of random players, then on every tick plays a random number of concurrent matches between random pairs of players, writing the outcome to the write endpoint.
+
+Configured under `simulator:` in `config.yaml`:
+
+```yaml
+simulator:
+  enabled: true
+  num_players: 50
+  tick_interval_millis: 2000
+  max_concurrent_matches: 5
+  seed: 42                      # to satisfy the PRNG gods (deterministic testing)
 ```
 
 ### Prometheus Metrics

--- a/config.yaml
+++ b/config.yaml
@@ -13,4 +13,10 @@ server:
 leaderboard:
   update_interval_secs: 5
   top_players_limit: 10
+simulator:
+  enabled: true
+  num_players: 50
+  tick_interval_millis: 500
+  max_concurrent_matches: 5
+  seed: 42
 metrics_enabled: false

--- a/src/backend/player.go
+++ b/src/backend/player.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"leaderboard/src/config"
 	"leaderboard/src/interfaces"
+	"leaderboard/src/models"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -21,7 +22,34 @@ func GetPlayerResults(store interfaces.LeaderboardStore) gin.HandlerFunc {
 			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "could not fetch player stats"})
 			return
 		}
-		config.Info("Results from player stats api", map[string]any{"id": playerID, "rank": rank, "score": score})
-		ctx.JSON(http.StatusOK, gin.H{"rank": rank, "score": score})
+		name, err := store.GetPlayerName(ctx, playerID)
+		if err != nil {
+			config.Error("Error getting player name", map[string]any{"Error": err})
+		}
+		config.Info("Results from player stats api", map[string]any{"id": playerID, "name": name, "rank": rank, "score": score})
+		ctx.JSON(http.StatusOK, gin.H{"player_id": playerID, "name": name, "rank": rank, "score": score})
+	}
+}
+
+//Accepts a JSON {player_id, name} and stores the mapping so that reads (leaderboard, stats, SSE) can return human-readable names alongside IDs.
+func RegisterPlayer(store interfaces.LeaderboardStore) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		var player models.Player
+		if err := ctx.ShouldBindJSON(&player); err != nil {
+			config.Error("Invalid JSON received for player registration", map[string]any{"Error": err})
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid json for player"})
+			return
+		}
+		if err := player.Validate(); err != nil {
+			config.Error("Player validation error", map[string]any{"Error": err})
+			ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if err := store.SetPlayerName(ctx, player.PlayerID, player.Name); err != nil {
+			config.Error("Could not register player", map[string]any{"Error": err, "player_id": player.PlayerID})
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "could not register player"})
+			return
+		}
+		ctx.JSON(http.StatusOK, gin.H{"status": "player registered", "player_id": player.PlayerID, "name": player.Name})
 	}
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -32,6 +32,14 @@ type Config struct {
 		CacheExpiryMins    int `yaml:"cache_expiry_mins"`
 	} `yaml:"leaderboard"`
 
+	Simulator struct {
+		Enabled            bool  `yaml:"enabled"`
+		NumPlayers         int   `yaml:"num_players"`
+		TickIntervalMillis int   `yaml:"tick_interval_millis"`
+		MaxConcurrent      int   `yaml:"max_concurrent_matches"`
+		Seed               int64 `yaml:"seed"`
+	} `yaml:"simulator"`
+
 	MetricsEnabled bool `yaml:"metrics_enabled"`
 }
 

--- a/src/interfaces/store.go
+++ b/src/interfaces/store.go
@@ -2,13 +2,19 @@ package interfaces
 
 import "context"
 
-type LeaderboardEntry struct{
-	PlayerID string
-	Score float64
+type LeaderboardEntry struct {
+	PlayerID string  `json:"player_id"`
+	Name     string  `json:"name"`
+	Score    float64 `json:"score"`
 }
 
 type LeaderboardStore interface {
 	UpdateLeaderboard(ctx context.Context, player1ID string, player2ID string, result int) error
 	GetTopNPlayers(ctx context.Context, limit int64) ([]LeaderboardEntry, error)
 	GetPlayerScore(ctx context.Context, playerID string) (int64, float64, error)
+
+	SetPlayerName(ctx context.Context, playerID string, name string) error
+	GetPlayerName(ctx context.Context, playerID string) (string, error)
+	// GetPlayerNames batch-resolves names for the given IDs. IDs without a stored name are simply absent from the returned map.
+	GetPlayerNames(ctx context.Context, playerIDs []string) (map[string]string, error)
 }

--- a/src/main.go
+++ b/src/main.go
@@ -7,6 +7,7 @@ import (
 	"leaderboard/src/config"
 	"leaderboard/src/metrics"
 	"leaderboard/src/redisclient"
+	"leaderboard/src/simulator"
 	"net/http"
 	"os"
 	"os/signal"
@@ -50,11 +51,21 @@ func main() {
 		config.Fatal("incorrect config passed to leaderboard constructor", map[string]any{"err": err})
 	}
 
+	sim := simulator.New(store, simulator.Config{
+		Enabled:            config.AppConfig.Simulator.Enabled,
+		NumPlayers:         config.AppConfig.Simulator.NumPlayers,
+		TickIntervalMillis: config.AppConfig.Simulator.TickIntervalMillis,
+		MaxConcurrent:      config.AppConfig.Simulator.MaxConcurrent,
+		Seed:               config.AppConfig.Simulator.Seed,
+	})
+	sim.Start()
+
 	r := gin.Default()
 
 	r.Use(metrics.MetricsMiddleware())
 
 	r.POST("/submit-game", backend.SubmitGameResults(store))
+	r.POST("/players", backend.RegisterPlayer(store))
 	r.GET("/stream-leaderboard", lb.StreamLeaderboard)
 	r.GET("/player/:id/stats", backend.GetPlayerResults(store))
 	r.GET("/leaderboard", backend.GetLeaderboard(store, int64(config.AppConfig.Leaderboard.TopPlayersLimit)))
@@ -91,6 +102,7 @@ func main() {
 		config.Error("Server forced to shutdown", map[string]any{"err": err})
 	}
 
+	sim.Stop()
 	lb.StopBroadcast()
 	config.Info("Server exiting", map[string]any{})
 }

--- a/src/models/models.go
+++ b/src/models/models.go
@@ -12,6 +12,24 @@ type GameResult struct {
 	Result    int    `json:"result" binding:"gte=0,lte=2"`
 }
 
+type Player struct {
+	PlayerID string `json:"player_id" binding:"required"`
+	Name     string `json:"name" binding:"required"`
+}
+
+func (p *Player) Validate() error {
+	if p.PlayerID == "" {
+		return &ValidationError{Field: "player_id", Reason: "empty string not allowed"}
+	}
+	if p.Name == "" {
+		return &ValidationError{Field: "name", Reason: "empty string not allowed"}
+	}
+	if len(p.Name) > 64 {
+		return &ValidationError{Field: "name", Reason: "name must be at most 64 characters"}
+	}
+	return nil
+}
+
 type ValidationError struct {
 	Field  string
 	Reason string

--- a/src/models/models.go
+++ b/src/models/models.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"fmt"
+        "strings"
+        "unicode/utf8"
 )
 
 type GameResult struct {
@@ -18,13 +20,13 @@ type Player struct {
 }
 
 func (p *Player) Validate() error {
-	if p.PlayerID == "" {
+	if strings.TrimSpace(p.PlayerID) == "" {
 		return &ValidationError{Field: "player_id", Reason: "empty string not allowed"}
 	}
-	if p.Name == "" {
+	if strings.TrimSpace(p.Name) == "" {
 		return &ValidationError{Field: "name", Reason: "empty string not allowed"}
 	}
-	if len(p.Name) > 64 {
+	if utf8.RuneCountInString(p.Name) > 64 {
 		return &ValidationError{Field: "name", Reason: "name must be at most 64 characters"}
 	}
 	return nil
@@ -40,16 +42,16 @@ func (e *ValidationError) Error() string {
 }
 
 func (g *GameResult) Validate() error {
-	if g.GameID == "" {
+	if strings.TrimSpace(g.GameID) == "" {
 		return &ValidationError{Field:"game_id", Reason:"empty string not allowed"}
 	}
-	if g.Player1ID == g.Player2ID {
+	if strings.TrimSpace(g.Player1ID) == strings.TrimSpace(g.Player2ID) {
 		return &ValidationError{Field: "player_id", Reason: "player ids cannot be the same"}
 	}
 	if g.Result < 0 || g.Result > 2 {
 		return &ValidationError{Field: "result", Reason: "result must be an integer between 0 and 2 inclusive"}
 	}
-	if g.ServerID == "" {
+	if strings.TrimSpace(g.ServerID) == "" {
 		return &ValidationError{Field: "server_id", Reason: "empty string not allowed"}
 	}
 	return nil

--- a/src/redisclient/redis.go
+++ b/src/redisclient/redis.go
@@ -13,6 +13,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const playerNamesKey = "player_names"
+
 type RedisLeaderboard struct {
 	client *redis.Client
 }
@@ -96,19 +98,79 @@ func (store *RedisLeaderboard) GetTopNPlayers(ctx context.Context, limit int64) 
 		return nil, config.Error("Failed to fetch top n players", map[string]any{"Error": err})
 	}
 	entries := make([]interfaces.LeaderboardEntry, 0, len(zs))
+	ids := make([]string, 0, len(zs))
 	for _, z := range zs {
 		playerID, ok := z.Member.(string)
 		if !ok {
 			return nil, fmt.Errorf("invalid redis member type")
 		}
-
+		ids = append(ids, playerID)
 		entries = append(entries, interfaces.LeaderboardEntry{
 			PlayerID: playerID,
 			Score:    z.Score,
 		})
 	}
 
+	names, err := store.GetPlayerNames(ctx, ids)
+	if err != nil {
+		config.Error("Failed to resolve player names for leaderboard", map[string]any{"Error": err})
+	} else {
+		for i := range entries {
+			entries[i].Name = names[entries[i].PlayerID]
+		}
+	}
+
 	return entries, nil
+}
+
+// Writes the display name for a player ID.
+func (store *RedisLeaderboard) SetPlayerName(ctx context.Context, playerID string, name string) error {
+	start := time.Now()
+	err := store.client.HSet(ctx, playerNamesKey, playerID, name).Err()
+	metrics.RedisLatency.Observe(time.Since(start).Seconds())
+	if err != nil {
+		metrics.RedisOperationErrors.WithLabelValues("set_player_name").Inc()
+		return config.Error("Failed to set player name", map[string]any{"Error": err, "player_id": playerID})
+	}
+	return nil
+}
+
+// Returns the display name for a player ID, empty string if unset.
+func (store *RedisLeaderboard) GetPlayerName(ctx context.Context, playerID string) (string, error) {
+	start := time.Now()
+	name, err := store.client.HGet(ctx, playerNamesKey, playerID).Result()
+	metrics.RedisLatency.Observe(time.Since(start).Seconds())
+	if errors.Is(err, redis.Nil) {
+		return "", nil
+	}
+	if err != nil {
+		metrics.RedisOperationErrors.WithLabelValues("get_player_name").Inc()
+		return "", config.Error("Failed to get player name", map[string]any{"Error": err, "player_id": playerID})
+	}
+	return name, nil
+}
+
+// Batch resolves display names via a single HMGet. IDs without a stored name are omitted from the returned map.
+func (store *RedisLeaderboard) GetPlayerNames(ctx context.Context, playerIDs []string) (map[string]string, error) {
+	names := make(map[string]string, len(playerIDs))
+	if len(playerIDs) == 0 {
+		return names, nil
+	}
+
+	start := time.Now()
+	vals, err := store.client.HMGet(ctx, playerNamesKey, playerIDs...).Result()
+	metrics.RedisLatency.Observe(time.Since(start).Seconds())
+	if err != nil {
+		metrics.RedisOperationErrors.WithLabelValues("get_player_names").Inc()
+		return nil, config.Error("Failed to batch-get player names", map[string]any{"Error": err})
+	}
+
+	for i, v := range vals {
+		if name, ok := v.(string); ok {
+			names[playerIDs[i]] = name
+		}
+	}
+	return names, nil
 }
 
 // GetPlayerScore returns the leaderboard rank and score for the given player ID in the specified sorted set key.

--- a/src/simulator/simulator.go
+++ b/src/simulator/simulator.go
@@ -35,8 +35,8 @@ type Simulator struct {
 
 func New(store interfaces.LeaderboardStore, cfg Config) *Simulator {
 	ctx, cancel := context.WithCancel(context.Background())
-        if cfg.TickerIntervalMillis < 0 {
-                cfg.TickerIntervalMillis = -cfg.TickerIntervalMillis
+        if cfg.TickIntervalMillis < 0 {
+                cfg.TickIntervalMillis = -cfg.TickIntervalMillis
         }
 	return &Simulator{
 		store:  store,
@@ -57,7 +57,7 @@ func (s *Simulator) Start() {
 		config.Error("Simulator needs at least 2 players, not starting", map[string]any{"num_players": s.cfg.NumPlayers})
 		return
 	}
-        if s.cfg.TickerIntervalMillis == 0 {
+        if s.cfg.TickIntervalMillis == 0 {
                 config.Error("Simulator tick interval must be positive", map[string]any{"tick_ms": s.cfg.TickIntervalMillis})
         }
 

--- a/src/simulator/simulator.go
+++ b/src/simulator/simulator.go
@@ -1,0 +1,155 @@
+// Drives synthetic write traffic against the leaderboard.
+
+package simulator
+
+import (
+	"context"
+	"fmt"
+	"leaderboard/src/config"
+	"leaderboard/src/interfaces"
+	"leaderboard/src/metrics"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+type Config struct {
+	Enabled            bool
+	NumPlayers         int
+	TickIntervalMillis int
+	MaxConcurrent      int // upper bound on matches played per tick
+	Seed               int64
+}
+
+type Simulator struct {
+	store   interfaces.LeaderboardStore
+	cfg     Config
+	players []string
+	rng     *rand.Rand
+	rngMu   sync.Mutex
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func New(store interfaces.LeaderboardStore, cfg Config) *Simulator {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Simulator{
+		store:  store,
+		cfg:    cfg,
+		rng:    rand.New(rand.NewSource(cfg.Seed)),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+// Seeds the player pool and launches the match loop in the background. Is a no-op if the simulator is disabled.
+func (s *Simulator) Start() {
+	if !s.cfg.Enabled {
+		config.Info("Match simulator disabled", map[string]any{})
+		return
+	}
+	if s.cfg.NumPlayers < 2 {
+		config.Error("Simulator needs at least 2 players, not starting", map[string]any{"num_players": s.cfg.NumPlayers})
+		return
+	}
+
+	s.seedPlayers()
+
+	s.wg.Add(1)
+	go s.run()
+
+	config.Info("Match simulator started", map[string]any{
+		"num_players":    s.cfg.NumPlayers,
+		"tick_ms":        s.cfg.TickIntervalMillis,
+		"max_concurrent": s.cfg.MaxConcurrent,
+	})
+}
+
+// Signals the match loop to exit and waits for in-flight matches to finish (graceful degradation like).
+func (s *Simulator) Stop() {
+	s.cancel()
+	s.wg.Wait()
+	config.Info("Match simulator stopped", map[string]any{})
+}
+
+// Creates the player pool and registers a display name for each.
+func (s *Simulator) seedPlayers() {
+	s.players = make([]string, 0, s.cfg.NumPlayers)
+	for i := 0; i < s.cfg.NumPlayers; i++ {
+		id := fmt.Sprintf("p_%04d", i)
+		s.players = append(s.players, id)
+		if err := s.store.SetPlayerName(s.ctx, id, randomName(s.rng, i)); err != nil {
+			config.Error("Failed to seed player name", map[string]any{"Error": err, "player_id": id})
+		}
+	}
+}
+
+func (s *Simulator) run() {
+	defer s.wg.Done()
+
+	interval := time.Duration(s.cfg.TickIntervalMillis) * time.Millisecond
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.playMatches()
+		case <-s.ctx.Done():
+			return
+		}
+	}
+}
+
+// Plays a random number of matches concurrently.
+func (s *Simulator) playMatches() {
+	s.rngMu.Lock()
+	count := 1 + s.rng.Intn(maxInt(1, s.cfg.MaxConcurrent))
+	s.rngMu.Unlock()
+
+	var wg sync.WaitGroup
+	for i := 0; i < count; i++ {
+		p1, p2, result := s.randomMatch()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := s.store.UpdateLeaderboard(s.ctx, p1, p2, result); err != nil {
+				config.Error("Simulated match failed to record", map[string]any{"Error": err})
+				return
+			}
+			metrics.GameSubmissions.Inc()
+		}()
+	}
+	wg.Wait()
+}
+
+// Picks two distinct random players and a random result (0/1/2).
+func (s *Simulator) randomMatch() (player1ID, player2ID string, result int) {
+	s.rngMu.Lock()
+	defer s.rngMu.Unlock()
+
+	i := s.rng.Intn(len(s.players))
+	j := s.rng.Intn(len(s.players))
+	for j == i {
+		j = s.rng.Intn(len(s.players))
+	}
+	return s.players[i], s.players[j], s.rng.Intn(3)
+}
+
+var (
+	adjectives = []string{"Swift", "Brave", "Silent", "Crimson", "Golden", "Shadow", "Iron", "Mystic", "Frost", "Blazing"}
+	nouns      = []string{"Falcon", "Tiger", "Wolf", "Phoenix", "Dragon", "Viper", "Knight", "Ranger", "Specter", "Titan"}
+)
+
+func randomName(rng *rand.Rand, n int) string {
+	return fmt.Sprintf("%s%s%d", adjectives[rng.Intn(len(adjectives))], nouns[rng.Intn(len(nouns))], n)
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/src/simulator/simulator.go
+++ b/src/simulator/simulator.go
@@ -35,6 +35,9 @@ type Simulator struct {
 
 func New(store interfaces.LeaderboardStore, cfg Config) *Simulator {
 	ctx, cancel := context.WithCancel(context.Background())
+        if cfg.TickerIntervalMillis < 0 {
+                cfg.TickerIntervalMillis = -cfg.TickerIntervalMillis
+        }
 	return &Simulator{
 		store:  store,
 		cfg:    cfg,
@@ -54,6 +57,9 @@ func (s *Simulator) Start() {
 		config.Error("Simulator needs at least 2 players, not starting", map[string]any{"num_players": s.cfg.NumPlayers})
 		return
 	}
+        if s.cfg.TickerIntervalMillis == 0 {
+                config.Error("Simulator tick interval must be positive", map[string]any{"tick_ms": s.cfg.TickIntervalMillis})
+        }
 
 	s.seedPlayers()
 

--- a/src/simulator/simulator.go
+++ b/src/simulator/simulator.go
@@ -59,6 +59,7 @@ func (s *Simulator) Start() {
 	}
         if s.cfg.TickIntervalMillis == 0 {
                 config.Error("Simulator tick interval must be positive", map[string]any{"tick_ms": s.cfg.TickIntervalMillis})
+                return
         }
 
 	s.seedPlayers()

--- a/src/simulator/simulator_test.go
+++ b/src/simulator/simulator_test.go
@@ -6,6 +6,7 @@ import (
 	"leaderboard/src/interfaces"
 	"sync"
 	"testing"
+        "time"
 
 	"go.uber.org/zap"
 )
@@ -141,7 +142,7 @@ func TestStartStopProducesWrites(t *testing.T) {
 	s := newTestSim(store, 6, 3)
 
 	s.Start()
-	// Stop blocks until the loop exits; with a 1ms tick at least one batch runs.
+	time.Sleep(100*time.Millisecond)
 	s.Stop()
 
 	if got := store.nameCount(); got != 6 {

--- a/src/simulator/simulator_test.go
+++ b/src/simulator/simulator_test.go
@@ -1,0 +1,153 @@
+package simulator
+
+import (
+	"context"
+	"leaderboard/src/config"
+	"leaderboard/src/interfaces"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func init() {
+	config.SetLogger(zap.NewNop())
+}
+
+// stubStore is a minimal concurrency-safe LeaderboardStore for simulator tests.
+// The simulator plays matches from multiple goroutines, so all access is locked.
+type stubStore struct {
+	mu      sync.Mutex
+	names   map[string]string
+	matches int
+}
+
+func newStubStore() *stubStore {
+	return &stubStore{names: make(map[string]string)}
+}
+
+func (s *stubStore) UpdateLeaderboard(ctx context.Context, p1, p2 string, result int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.matches++
+	return nil
+}
+
+func (s *stubStore) SetPlayerName(ctx context.Context, playerID, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.names[playerID] = name
+	return nil
+}
+
+func (s *stubStore) nameCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.names)
+}
+
+func (s *stubStore) matchCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.matches
+}
+
+// Unused by the simulator but required to satisfy the interface.
+func (s *stubStore) GetTopNPlayers(ctx context.Context, limit int64) ([]interfaces.LeaderboardEntry, error) {
+	return nil, nil
+}
+func (s *stubStore) GetPlayerScore(ctx context.Context, playerID string) (int64, float64, error) {
+	return 0, 0, nil
+}
+func (s *stubStore) GetPlayerName(ctx context.Context, playerID string) (string, error) {
+	return "", nil
+}
+func (s *stubStore) GetPlayerNames(ctx context.Context, ids []string) (map[string]string, error) {
+	return nil, nil
+}
+
+func newTestSim(store interfaces.LeaderboardStore, numPlayers, maxConcurrent int) *Simulator {
+	return New(store, Config{
+		Enabled:            true,
+		NumPlayers:         numPlayers,
+		TickIntervalMillis: 1,
+		MaxConcurrent:      maxConcurrent,
+		Seed:               42,
+	})
+}
+
+func TestSeedPlayers(t *testing.T) {
+	store := newStubStore()
+	s := newTestSim(store, 10, 3)
+
+	s.seedPlayers()
+
+	if len(s.players) != 10 {
+		t.Fatalf("expected 10 players in pool, got %d", len(s.players))
+	}
+	if got := store.nameCount(); got != 10 {
+		t.Fatalf("expected 10 names registered, got %d", got)
+	}
+}
+
+func TestRandomMatchPicksDistinctPlayers(t *testing.T) {
+	store := newStubStore()
+	s := newTestSim(store, 5, 3)
+	s.seedPlayers()
+
+	for i := 0; i < 1000; i++ {
+		p1, p2, result := s.randomMatch()
+		if p1 == p2 {
+			t.Fatalf("randomMatch returned identical players: %s", p1)
+		}
+		if result < 0 || result > 2 {
+			t.Fatalf("result out of range [0,2]: %d", result)
+		}
+	}
+}
+
+func TestPlayMatchesRespectsBound(t *testing.T) {
+	store := newStubStore()
+	const maxConcurrent = 5
+	s := newTestSim(store, 8, maxConcurrent)
+	s.seedPlayers()
+
+	// A single batch must play between 1 and maxConcurrent matches.
+	s.playMatches()
+
+	got := store.matchCount()
+	if got < 1 || got > maxConcurrent {
+		t.Fatalf("expected between 1 and %d matches, got %d", maxConcurrent, got)
+	}
+}
+
+func TestStartDisabledIsNoop(t *testing.T) {
+	store := newStubStore()
+	s := New(store, Config{Enabled: false, NumPlayers: 10, MaxConcurrent: 3, TickIntervalMillis: 1})
+
+	s.Start()
+	defer s.Stop()
+
+	if len(s.players) != 0 {
+		t.Fatalf("disabled simulator should not seed players, got %d", len(s.players))
+	}
+	if got := store.matchCount(); got != 0 {
+		t.Fatalf("disabled simulator should not play matches, got %d", got)
+	}
+}
+
+func TestStartStopProducesWrites(t *testing.T) {
+	store := newStubStore()
+	s := newTestSim(store, 6, 3)
+
+	s.Start()
+	// Stop blocks until the loop exits; with a 1ms tick at least one batch runs.
+	s.Stop()
+
+	if got := store.nameCount(); got != 6 {
+		t.Fatalf("expected 6 players seeded, got %d", got)
+	}
+	if store.matchCount() == 0 {
+		t.Fatalf("expected at least one match to be recorded after start/stop")
+	}
+}

--- a/tests/unit/leaderboard_test.go
+++ b/tests/unit/leaderboard_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"leaderboard/src/interfaces"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
@@ -21,11 +20,8 @@ func TestLeaderboard_Success(t *testing.T) {
 	}
 	r := CreateTestRouter(store)
 
-	w := httptest.NewRecorder()
 	var resp []interfaces.LeaderboardEntry
-	req, _ := http.NewRequest("GET", "/leaderboard", nil)
-
-	r.ServeHTTP(w, req)
+	w := performRequest(r, "GET", "/leaderboard", "")
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected status code 200, got %d", w.Code)
@@ -35,8 +31,8 @@ func TestLeaderboard_Success(t *testing.T) {
 		t.Fatalf("error while unmarshaling response: %v", err)
 	}
 
-	if !(store.timesCalled == 1) {
-		t.Fatalf("expected store to be called, timesCalled is %d", store.timesCalled)
+	if got := store.callCount("GetTopNPlayers"); got != 1 {
+		t.Fatalf("expected GetTopNPlayers to be called once, got %d", got)
 	}
 
 	if len(resp) != 2 {
@@ -60,10 +56,7 @@ func TestLeaderboard_StoreDown(t *testing.T){
 	}
 	r := CreateTestRouter(store)
 
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/leaderboard", nil)
-
-	r.ServeHTTP(w, req)
+	w := performRequest(r, "GET", "/leaderboard", "")
 
 	if w.Code!=http.StatusInternalServerError{
 		t.Fatalf("expected code 500, got %d", w.Code)

--- a/tests/unit/player_model_test.go
+++ b/tests/unit/player_model_test.go
@@ -1,0 +1,70 @@
+package unit_test
+
+import (
+	"errors"
+	"leaderboard/src/models"
+	"strings"
+	"testing"
+)
+
+func TestPlayerValidate(t *testing.T) {
+	cases := []struct {
+		name         string
+		input        models.Player
+		wantErr      bool
+		wantErrField string
+	}{
+		{
+			name:    "valid player",
+			input:   models.Player{PlayerID: "p_0001", Name: "SwiftFalcon"},
+			wantErr: false,
+		},
+		{
+			name:         "empty player id",
+			input:        models.Player{PlayerID: "", Name: "SwiftFalcon"},
+			wantErr:      true,
+			wantErrField: "player_id",
+		},
+		{
+			name:         "empty name",
+			input:        models.Player{PlayerID: "p_0001", Name: ""},
+			wantErr:      true,
+			wantErrField: "name",
+		},
+		{
+			name:         "name too long",
+			input:        models.Player{PlayerID: "p_0001", Name: strings.Repeat("a", 65)},
+			wantErr:      true,
+			wantErrField: "name",
+		},
+		{
+			name:    "name at max length",
+			input:   models.Player{PlayerID: "p_0001", Name: strings.Repeat("a", 64)},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.input.Validate()
+
+			if !tc.wantErr {
+				if got != nil {
+					t.Fatalf("unexpected validation error: %v", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatalf("expected error, got none")
+			}
+			var ve *models.ValidationError
+			if !errors.As(got, &ve) {
+				t.Fatalf("expected *models.ValidationError, got %T", got)
+			}
+			if ve.Field != tc.wantErrField {
+				t.Fatalf("expected error field %q, got %q", tc.wantErrField, ve.Field)
+			}
+		})
+	}
+}

--- a/tests/unit/player_test.go
+++ b/tests/unit/player_test.go
@@ -5,26 +5,25 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 )
 
 func TestPlayer_Success(t *testing.T) {
 	store := &fakeLeaderboardStore{
+		playerNames: map[string]string{"12": "SwiftFalcon"},
 		GetPlayerScoreFn: func(ctx context.Context, playerID string) (int64, float64, error) {
 			return 1, 2.5, nil
 		},
 	}
 	r := CreateTestRouter(store)
 
-	w := httptest.NewRecorder()
 	var resp struct {
-		Rank  int64
-		Score float64
+		PlayerID string  `json:"player_id"`
+		Name     string  `json:"name"`
+		Rank     int64   `json:"rank"`
+		Score    float64 `json:"score"`
 	}
-	req, _ := http.NewRequest("GET", "/player/12/stats", nil)
-
-	r.ServeHTTP(w, req)
+	w := performRequest(r, "GET", "/player/12/stats", "")
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected status code 200, got %d", w.Code)
@@ -34,8 +33,12 @@ func TestPlayer_Success(t *testing.T) {
 		t.Fatalf("error while unmarshaling response: %v", err)
 	}
 
-	if store.timesCalled != 1 {
-		t.Fatalf("expected store to be called, timesCalled is %d", store.timesCalled)
+	// stats handler resolves the score and the display name exactly once each
+	if got := store.callCount("GetPlayerScore"); got != 1 {
+		t.Fatalf("expected GetPlayerScore called once, got %d", got)
+	}
+	if got := store.callCount("GetPlayerName"); got != 1 {
+		t.Fatalf("expected GetPlayerName called once, got %d", got)
 	}
 
 	if resp.Rank != 1 {
@@ -44,6 +47,10 @@ func TestPlayer_Success(t *testing.T) {
 
 	if resp.Score != 2.5 {
 		t.Fatalf("expected score 2.5, got %f", resp.Score)
+	}
+
+	if resp.Name != "SwiftFalcon" {
+		t.Fatalf("expected name SwiftFalcon, got %q", resp.Name)
 	}
 }
 
@@ -55,10 +62,7 @@ func TestPlayer_BadRequest(t *testing.T) {
 	}
 	r := CreateTestRouter(store)
 
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/player//stats", nil)
-
-	r.ServeHTTP(w, req)
+	w := performRequest(r, "GET", "/player//stats", "")
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected status code 400, got %d", w.Code)
@@ -73,10 +77,7 @@ func TestPlayer_StoreDown(t *testing.T) {
 	}
 	r := CreateTestRouter(store)
 
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/player/42/stats", nil)
-
-	r.ServeHTTP(w, req)
+	w := performRequest(r, "GET", "/player/42/stats", "")
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("expected status code 500, got %d", w.Code)

--- a/tests/unit/register_player_test.go
+++ b/tests/unit/register_player_test.go
@@ -1,0 +1,61 @@
+package unit_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestRegisterPlayer(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       string
+		wantStatus int
+		wantStored bool // whether SetPlayerName should have been invoked
+	}{
+		{
+			name:       "valid registration",
+			body:       `{"player_id":"p_0001","name":"SwiftFalcon"}`,
+			wantStatus: http.StatusOK,
+			wantStored: true,
+		},
+		{
+			name:       "missing name",
+			body:       `{"player_id":"p_0001"}`,
+			wantStatus: http.StatusBadRequest,
+			wantStored: false,
+		},
+		{
+			name:       "missing player id",
+			body:       `{"name":"SwiftFalcon"}`,
+			wantStatus: http.StatusBadRequest,
+			wantStored: false,
+		},
+		{
+			name:       "malformed json",
+			body:       `{"player_id":`,
+			wantStatus: http.StatusBadRequest,
+			wantStored: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeLeaderboardStore{}
+			r := CreateTestRouter(store)
+
+			w := performRequest(r, "POST", "/players", tc.body)
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("expected status %d, got %d (%s)", tc.wantStatus, w.Code, w.Body.String())
+			}
+
+			gotStored := store.callCount("SetPlayerName") > 0
+			if gotStored != tc.wantStored {
+				t.Fatalf("expected stored=%v, got %v", tc.wantStored, gotStored)
+			}
+			if tc.wantStored && store.playerNames["p_0001"] != "SwiftFalcon" {
+				t.Fatalf("expected name to be stored, got %q", store.playerNames["p_0001"])
+			}
+		})
+	}
+}

--- a/tests/unit/setup_test.go
+++ b/tests/unit/setup_test.go
@@ -15,7 +15,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// fakeLeaderboardStore is a concurrency-safe in-memory test double. It records both a total call count (timesCalled, kept for existing assertions) and a per-method count so tests can assert on a specific method without coupling to the total number of store interactions.
+// Concurrency-safe mock. Records total call count and per-method count.
 type fakeLeaderboardStore struct {
 	mu        sync.Mutex
 	calls     map[string]int
@@ -30,7 +30,7 @@ type fakeLeaderboardStore struct {
 	GetTopNPlayersFn func(ctx context.Context, limit int64) ([]interfaces.LeaderboardEntry, error)
 }
 
-// Increments the per-method and total counters under the lock.
+// Increment the per-method and total counters in a concurrency safe manner.
 func (store *fakeLeaderboardStore) record(method string) {
 	if store.calls == nil {
 		store.calls = make(map[string]int)
@@ -45,7 +45,6 @@ func (store *fakeLeaderboardStore) callCount(method string) int {
 	return store.calls[method]
 }
 
-// Returns the number of store method invocations across all methods.
 func (store *fakeLeaderboardStore) totalCalls() int {
 	store.mu.Lock()
 	defer store.mu.Unlock()
@@ -134,13 +133,12 @@ func CreateTestRouter(store interfaces.LeaderboardStore) *gin.Engine {
 	return r
 }
 
-// Builds a request (with an optional body) and serves it against the router, returning the recorder. body may be "" for GET requests.
 func performRequest(r http.Handler, method, path, body string) *httptest.ResponseRecorder {
 	var reader io.Reader
 	if body != "" {
 		reader = strings.NewReader(body)
 	}
-	req, _ := http.NewRequest(method, path, reader)
+	req, _ := httptest.NewRequest(method, path, reader)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	return w

--- a/tests/unit/setup_test.go
+++ b/tests/unit/setup_test.go
@@ -138,7 +138,7 @@ func performRequest(r http.Handler, method, path, body string) *httptest.Respons
 	if body != "" {
 		reader = strings.NewReader(body)
 	}
-	req, _ := httptest.NewRequest(method, path, reader)
+	req := httptest.NewRequest(method, path, reader)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	return w

--- a/tests/unit/setup_test.go
+++ b/tests/unit/setup_test.go
@@ -2,45 +2,119 @@ package unit_test
 
 import (
 	"context"
+	"io"
 	"leaderboard/src/backend"
 	"leaderboard/src/config"
 	"leaderboard/src/interfaces"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
 
+// fakeLeaderboardStore is a concurrency-safe in-memory test double. It records both a total call count (timesCalled, kept for existing assertions) and a per-method count so tests can assert on a specific method without coupling to the total number of store interactions.
 type fakeLeaderboardStore struct {
-	timesCalled int
-	player1ID   string
-	player2ID   string
-	result      int
+	mu        sync.Mutex
+	calls     map[string]int
+	player1ID string
+	player2ID string
+	result    int
+
+	playerNames map[string]string
 
 	// configurable fakes
 	GetPlayerScoreFn func(ctx context.Context, playerID string) (int64, float64, error)
 	GetTopNPlayersFn func(ctx context.Context, limit int64) ([]interfaces.LeaderboardEntry, error)
 }
 
+// Increments the per-method and total counters under the lock.
+func (store *fakeLeaderboardStore) record(method string) {
+	if store.calls == nil {
+		store.calls = make(map[string]int)
+	}
+	store.calls[method]++
+}
+
+// Returns how many times a specific method was invoked.
+func (store *fakeLeaderboardStore) callCount(method string) int {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	return store.calls[method]
+}
+
+// Returns the number of store method invocations across all methods.
+func (store *fakeLeaderboardStore) totalCalls() int {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	total := 0
+	for _, n := range store.calls {
+		total += n
+	}
+	return total
+}
+
+func (store *fakeLeaderboardStore) SetPlayerName(ctx context.Context, playerID string, name string) error {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.record("SetPlayerName")
+	if store.playerNames == nil {
+		store.playerNames = make(map[string]string)
+	}
+	store.playerNames[playerID] = name
+	return nil
+}
+
+func (store *fakeLeaderboardStore) GetPlayerName(ctx context.Context, playerID string) (string, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.record("GetPlayerName")
+	return store.playerNames[playerID], nil
+}
+
+func (store *fakeLeaderboardStore) GetPlayerNames(ctx context.Context, playerIDs []string) (map[string]string, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.record("GetPlayerNames")
+	names := make(map[string]string, len(playerIDs))
+	for _, id := range playerIDs {
+		if name, ok := store.playerNames[id]; ok {
+			names[id] = name
+		}
+	}
+	return names, nil
+}
+
 func (store *fakeLeaderboardStore) UpdateLeaderboard(ctx context.Context, player1ID string, player2ID string, result int) error {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	store.record("UpdateLeaderboard")
 	store.player1ID = player1ID
 	store.player2ID = player2ID
-	store.timesCalled += 1
 	store.result = result
 	return nil
 }
 
 func (store *fakeLeaderboardStore) GetPlayerScore(ctx context.Context, playerID string) (int64, float64, error) {
-	store.timesCalled += 1
-	if store.GetPlayerScoreFn != nil {
-		return store.GetPlayerScoreFn(ctx, playerID)
+	store.mu.Lock()
+	store.record("GetPlayerScore")
+	fn := store.GetPlayerScoreFn
+	store.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, playerID)
 	}
 	return 0, 0.0, nil
 }
 
 func (store *fakeLeaderboardStore) GetTopNPlayers(ctx context.Context, limit int64) ([]interfaces.LeaderboardEntry, error) {
-	store.timesCalled += 1
-	if store.GetTopNPlayersFn != nil {
-		return store.GetTopNPlayersFn(ctx, limit)
+	store.mu.Lock()
+	store.record("GetTopNPlayers")
+	fn := store.GetTopNPlayersFn
+	store.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, limit)
 	}
 	return nil, nil
 }
@@ -54,7 +128,20 @@ func CreateTestRouter(store interfaces.LeaderboardStore) *gin.Engine {
 	r := gin.New()
 
 	r.POST("/submit-game", backend.SubmitGameResults(store))
+	r.POST("/players", backend.RegisterPlayer(store))
 	r.GET("/player/:id/stats", backend.GetPlayerResults(store))
 	r.GET("/leaderboard", backend.GetLeaderboard(store, 10))
 	return r
+}
+
+// Builds a request (with an optional body) and serves it against the router, returning the recorder. body may be "" for GET requests.
+func performRequest(r http.Handler, method, path, body string) *httptest.ResponseRecorder {
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	req, _ := http.NewRequest(method, path, reader)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
 }

--- a/tests/unit/submitgame_test.go
+++ b/tests/unit/submitgame_test.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"leaderboard/src/models"
 	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 )
 
@@ -13,19 +11,16 @@ func TestSubmitGameResults_Success(t *testing.T) {
 	store := &fakeLeaderboardStore{}
 	r := CreateTestRouter(store)
 
-	w := httptest.NewRecorder()
 	gameResult := &models.GameResult{GameID: "12", ServerID: "54", Player1ID: "1", Player2ID: "2", Result: 2}
 	gameJSON, _ := json.Marshal(gameResult)
-	req, _ := http.NewRequest("POST", "/submit-game", strings.NewReader(string(gameJSON)))
-
-	r.ServeHTTP(w, req)
+	w := performRequest(r, "POST", "/submit-game", string(gameJSON))
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected status code 200, got %d", w.Code)
 	}
 
-	if !(store.timesCalled == 1) {
-		t.Fatalf("expected store to be called, timesCalled is %d", store.timesCalled)
+	if got := store.callCount("UpdateLeaderboard"); got != 1 {
+		t.Fatalf("expected UpdateLeaderboard to be called once, got %d", got)
 	}
 
 	if store.player1ID != "1" || store.player2ID != "2" || store.result != 2 {
@@ -86,18 +81,16 @@ func TestSubmitGameResults_Failure(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			store := &fakeLeaderboardStore{}
 			r := CreateTestRouter(store)
-			w := httptest.NewRecorder()
 
-			req, _ := http.NewRequest("POST", "/submit-game", strings.NewReader(testCase.gameResult))
-			r.ServeHTTP(w, req)
+			w := performRequest(r, "POST", "/submit-game", testCase.gameResult)
 
 			// failure cases - want these requests to fail
 			if w.Code == http.StatusOK {
 				t.Fatalf("expected status code not equal to 200")
 			}
 
-			if store.timesCalled > 0 {
-				t.Fatalf("store should not be called in failure, called %d times", store.timesCalled)
+			if got := store.totalCalls(); got > 0 {
+				t.Fatalf("store should not be called in failure, called %d times", got)
 			}
 		})
 	}


### PR DESCRIPTION
These are the two features I wanted to include to make this project feel like a real project and not an experiment in scaling.

Reads would surface the player ids along with their scores and rank for any read endpoint earlier. This will now also include a username, which is mapped from redis hashed. In the future this can be taken from postgres first to fill in the hash (hash acts like a cache here, plus not point in introducing a db read in the read path which is pretty simple).

The second change is to introduce simulation of writers, this is not complete yet, but will make the benchmarks complete, throughput metrics and latency can be observed, so we will get an idea of how a real system with writes and reads (and not just connections) will scale. A much needed change which should have been done a year ago.

Still working on pprof and postgres integration.